### PR TITLE
fix(a11y): a11y inconclusive stuff

### DIFF
--- a/packages/ds/.storybook/test-runner.ts
+++ b/packages/ds/.storybook/test-runner.ts
@@ -13,11 +13,14 @@ const config: TestRunnerConfig = {
       .filter((r: { enabled: boolean }) => r.enabled === false)
       .map((r: { id: string }) => r.id);
 
+    const axeRules = Object.fromEntries(
+      disabledRules.map((id: string) => [id, { enabled: false }]),
+    );
+
     await checkA11y(page, '#storybook-root', {
       axeOptions: {
-        rules: Object.fromEntries(
-          disabledRules.map((id: string) => [id, { enabled: false }]),
-        ),
+        rules: axeRules,
+        resultTypes: ['violations', 'incomplete'],
       },
       detailedReport: true,
       detailedReportOptions: { html: true },

--- a/packages/ds/src/components/TaskRow/TaskRow.module.css
+++ b/packages/ds/src/components/TaskRow/TaskRow.module.css
@@ -138,9 +138,11 @@
 }
 
 .separator {
-  color: var(--ds-color-text-disabled);
-  font-size: var(--ds-text-metadata-font-size);
-  line-height: 1;
+  width: 3px;
+  height: 3px;
+  border-radius: var(--ds-radius-full);
+  background-color: var(--ds-color-text-disabled);
+  flex-shrink: 0;
 }
 
 .completed {

--- a/packages/ds/src/components/TaskRow/TaskRow.test.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.test.tsx
@@ -143,7 +143,7 @@ describe('TaskRow', () => {
     );
     const separator = container.querySelector('[aria-hidden="true"]');
     expect(separator).toBeInTheDocument();
-    expect(separator).toHaveTextContent('·');
+    expect(separator).toBeEmptyDOMElement();
   });
 
   it('does not render separator when only ticket is provided', () => {

--- a/packages/ds/src/components/TaskRow/TaskRow.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.tsx
@@ -107,9 +107,7 @@ export const TaskRow = forwardRef<HTMLDivElement, TaskRowProps>(
             </div>
           )}
           {ticketId && date && (
-            <span className={styles.separator} aria-hidden="true">
-              ·
-            </span>
+            <span className={styles.separator} aria-hidden="true" />
           )}
           {date && (
             <div className={styles.date}>


### PR DESCRIPTION
- replace text separator with CSS dot to resolve inconclusive contrast check

- adding inconclusive as a violation on a11y
- 
<img width="2556" height="1417" alt="aeewrw" src="https://github.com/user-attachments/assets/73e87c6a-c3bc-4556-b737-ffdbf1110fcc" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: limited to Storybook a11y test configuration and a small visual-only separator change in `TaskRow`, with updated unit expectations.
> 
> **Overview**
> Improves Storybook accessibility testing by reusing the derived disabled axe rules and expanding axe output to include `incomplete` results alongside `violations`.
> 
> Updates `TaskRow`’s compact ticket/date separator from a text "·" to an empty, `aria-hidden` element styled as a CSS dot, and adjusts the corresponding test assertion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1192c9a2f16d0ff4c89561c9cb06977c1ad5406. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->