### PR TITLE
fix(DateCell): add control for date param

### DIFF
--- a/packages/ds/src/components/DateCell/DateCell.tsx
+++ b/packages/ds/src/components/DateCell/DateCell.tsx
@@ -3,6 +3,7 @@ import { cn } from '../../utils/cn';
 import styles from './DateCell.module.css';
 
 export interface DateCellProps extends HTMLAttributes<HTMLTimeElement> {
+  /** Display label — e.g. "Today", "Mar 15", "2 days ago" */
   date: string;
   urgent?: boolean;
   dateTime: string;

--- a/packages/ds/src/components/TaskRow/TaskRow.stories.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.stories.tsx
@@ -19,6 +19,7 @@ const meta = {
       options: ['critical', 'high', 'medium', 'low'],
     },
     ticketId: { control: 'text' },
+    date: { control: 'object' },
     layout: {
       control: 'select',
       options: ['default', 'compact'],


### PR DESCRIPTION
<img width="1715" height="1070" alt="date-cell-date" src="https://github.com/user-attachments/assets/b859e49d-6c84-445c-9035-2af3a20222b2" />
<img width="1728" height="1078" alt="task-row-cell" src="https://github.com/user-attachments/assets/7907bac4-09a1-462a-8ce6-8de858a627c5" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a prop doc comment and Storybook configuration, with no runtime logic or data-flow modifications.
> 
> **Overview**
> Clarifies the `DateCell` `date` prop by adding an inline doc comment describing the expected display label.
> 
> Updates `TaskRow` Storybook metadata to include a controllable `date` arg (`control: 'object'`), enabling interactive editing of the date payload in stories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b09b6c7b54cc3b392a766f883ef5de2461e29798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->