### PR TITLE
refactor(selector): add useSelectorState/Group hooks, fix a11y, and c…

### DIFF
--- a/packages/ds/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ds/src/components/Drawer/Drawer.stories.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import { withDefaultViewport } from '../../../.storybook/decorators';
@@ -13,7 +13,7 @@ import { IconButton } from '../IconButton';
 import { FloatingSearch } from '../FloatingSearch';
 import { MobileSearchSheet } from '../MobileSearchSheet';
 import type { SearchPaletteGroup } from '../SearchPalette';
-import { useClickOutside } from '../../hooks/useClickOutside';
+import { useSelectorState } from '../../hooks/useSelector';
 
 const projects = [
   { value: 'eng-core', label: 'Engineering Core' },
@@ -41,11 +41,8 @@ type Story = StoryObj<typeof Drawer>;
 
 function SidebarContent() {
   const [project, setProject] = useState('eng-core');
-  const [selectorOpen, setSelectorOpen] = useState(false);
   const [activeNav, setActiveNav] = useState('tasks');
-  const selectorRef = useRef<HTMLDivElement>(null);
-  const closeSelector = useCallback(() => setSelectorOpen(false), []);
-  useClickOutside(selectorRef, closeSelector, selectorOpen);
+  const { ref, open, onOpenChange } = useSelectorState();
   const avatar = avatars[project];
   const navClick = (id: string) => (e: React.MouseEvent) => {
     e.preventDefault();
@@ -56,12 +53,12 @@ function SidebarContent() {
     <Sidebar
       header={
         <Selector
-          ref={selectorRef}
+          ref={ref}
           options={projects}
           value={project}
           onValueChange={setProject}
-          open={selectorOpen}
-          onOpenChange={setSelectorOpen}
+          open={open}
+          onOpenChange={onOpenChange}
           triggerPrefix={
             <Avatar initial={avatar.initial} aria-label={avatar.label} />
           }

--- a/packages/ds/src/components/Selector/Selector.module.css
+++ b/packages/ds/src/components/Selector/Selector.module.css
@@ -45,12 +45,12 @@
   color: var(--ds-color-text-secondary);
 }
 
-.iconTrigger {
+.inlineTrigger {
   width: auto;
   gap: var(--ds-space-scale-xs);
 }
 
-.iconTrigger .label {
+.inlineTrigger .label {
   flex: 0 1 auto;
   font-size: var(--ds-text-property-row-value-font-size);
   font-family: var(--ds-text-property-row-value-font-family);
@@ -81,11 +81,11 @@
 }
 
 .header {
-  padding: var(--ds-space-scale-sm) var(--ds-space-nav-item-padding-x);
+  padding: var(--ds-space-scale-sm) var(--ds-space-nav-item-padding-x) 0;
   border-bottom: 1px solid var(--ds-color-border-default);
 }
 
-.header > div {
+.header > :last-child {
   border-bottom: none;
 }
 
@@ -149,7 +149,7 @@
 .optionPrefix {
   flex-shrink: 0;
   min-width: var(--ds-space-ticket-id-min-width);
-  text-align: right;
+  text-align: left;
   font-size: var(--ds-text-ticket-id-font-size);
   font-family: var(--ds-text-ticket-id-font-family);
   font-weight: var(--ds-font-weight-bold);

--- a/packages/ds/src/components/Selector/Selector.stories.tsx
+++ b/packages/ds/src/components/Selector/Selector.stories.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Selector, type SelectorProps } from './Selector';
 import { Avatar } from '../Avatar';
 import { SearchInput } from '../SearchInput';
-import { useClickOutside } from '../../hooks/useClickOutside';
+import { useSelectorState } from '../../hooks/useSelector';
 
 const projects = [
   { value: 'eng-core', label: 'Engineering Core' },
@@ -21,6 +21,17 @@ const meta: Meta<typeof Selector> = {
   title: 'Components/Selector',
   component: Selector,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          'Selector is fully controlled — pair it with a state hook:',
+          '- **`useSelectorState`** — standalone selector with click-outside detection.',
+          '- **`useSelectorGroup`** — multiple selectors with mutual exclusion (only one open at a time). Use `useSelectorState` instead when selectors are independent and may open simultaneously.',
+        ].join('\n'),
+      },
+    },
+  },
   argTypes: {
     options: { control: 'object' },
     action: { control: 'object' },
@@ -41,10 +52,7 @@ type RenderProps = Pick<SelectorProps, 'options' | 'action'>;
 
 function DefaultRender({ options }: RenderProps) {
   const [value, setValue] = useState('eng-core');
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   const avatar = avatars[value];
   return (
     <Selector
@@ -53,7 +61,7 @@ function DefaultRender({ options }: RenderProps) {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       triggerPrefix={
         <Avatar initial={avatar.initial} aria-label={avatar.label} />
       }
@@ -68,10 +76,7 @@ export const Default: Story = {
 
 function WithActionRender({ options, action }: RenderProps) {
   const [value, setValue] = useState('eng-core');
-  const [open, setOpen] = useState(true);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   const avatar = avatars[value];
   return (
     <Selector
@@ -80,7 +85,7 @@ function WithActionRender({ options, action }: RenderProps) {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       triggerPrefix={
         <Avatar initial={avatar.initial} aria-label={avatar.label} />
       }
@@ -105,10 +110,7 @@ export const WithAction: Story = {
 
 function NoSelectionRender({ options }: RenderProps) {
   const [value, setValue] = useState<string | undefined>(undefined);
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   const avatar = value ? avatars[value] : undefined;
   return (
     <Selector
@@ -117,7 +119,7 @@ function NoSelectionRender({ options }: RenderProps) {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       placeholder="Choose project…"
       triggerPrefix={
         avatar ? (
@@ -164,10 +166,7 @@ const priorityOptions = [
 
 function IconOptionsRender({ options }: RenderProps) {
   const [value, setValue] = useState('high');
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   return (
     <Selector
       ref={ref}
@@ -175,8 +174,8 @@ function IconOptionsRender({ options }: RenderProps) {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
-      size="sm"
+      onOpenChange={onOpenChange}
+      variant="inline"
       aria-label="Select priority"
     />
   );
@@ -203,11 +202,8 @@ const allTickets = [
 
 function SearchableRender() {
   const [value, setValue] = useState('T-42');
-  const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
 
   const filtered = query
     ? allTickets.filter(
@@ -227,7 +223,7 @@ function SearchableRender() {
         setQuery('');
       }}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       header={
         <SearchInput
           value={query}
@@ -241,7 +237,7 @@ function SearchableRender() {
         icon: 'add' as const,
         onClick: () => {},
       }}
-      size="sm"
+      variant="inline"
       emptyState="No results found"
       aria-label="Linked ticket"
     />
@@ -259,10 +255,7 @@ const manyOptions = Array.from({ length: 20 }, (_, i) => ({
 
 function ManyOptionsRender({ options }: RenderProps) {
   const [value, setValue] = useState('opt-1');
-  const [open, setOpen] = useState(true);
-  const ref = useRef<HTMLDivElement>(null);
-  const close = useCallback(() => setOpen(false), []);
-  useClickOutside(ref, close, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   return (
     <Selector
       ref={ref}
@@ -270,7 +263,7 @@ function ManyOptionsRender({ options }: RenderProps) {
       value={value}
       onValueChange={setValue}
       open={open}
-      onOpenChange={setOpen}
+      onOpenChange={onOpenChange}
       aria-label="Many options"
     />
   );

--- a/packages/ds/src/components/Selector/Selector.test.tsx
+++ b/packages/ds/src/components/Selector/Selector.test.tsx
@@ -112,6 +112,21 @@ describe('Selector', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('closes dropdown when action is clicked', async () => {
+    const onOpenChange = vi.fn();
+    render(
+      <Selector
+        options={options}
+        value="a"
+        open
+        onOpenChange={onOpenChange}
+        action={{ label: 'Add item', icon: 'add', onClick: () => {} }}
+      />,
+    );
+    await userEvent.click(screen.getByText('Add item'));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('sets aria-expanded on trigger', () => {
     const { rerender } = render(<Selector options={options} value="a" />);
     expect(screen.getByRole('button')).toHaveAttribute(
@@ -120,6 +135,26 @@ describe('Selector', () => {
     );
     rerender(<Selector options={options} value="a" open />);
     expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('sets aria-controls on trigger when open', () => {
+    const { rerender } = render(
+      <Selector options={options} value="a" id="test" />,
+    );
+    expect(screen.getByRole('button')).not.toHaveAttribute('aria-controls');
+    rerender(<Selector options={options} value="a" id="test" open />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-controls',
+      'test-listbox',
+    );
+  });
+
+  it('sets aria-label on trigger button', () => {
+    render(<Selector options={options} value="a" aria-label="Choose option" />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Choose option',
+    );
   });
 
   it('forwards ref to container div', () => {
@@ -133,6 +168,18 @@ describe('Selector', () => {
       <Selector options={options} value="a" className="custom" />,
     );
     expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('focuses selected option when dropdown opens', () => {
+    render(<Selector options={options} value="b" open />);
+    const selected = screen.getByRole('option', { selected: true });
+    expect(selected).toHaveFocus();
+  });
+
+  it('focuses first option when dropdown opens with no selection', () => {
+    render(<Selector options={options} open />);
+    const opts = screen.getAllByRole('option');
+    expect(opts[0]).toHaveFocus();
   });
 
   describe('keyboard navigation', () => {
@@ -321,6 +368,36 @@ describe('Selector', () => {
     });
 
     it('shows prefix · label in trigger', () => {
+      render(<Selector options={prefixOptions} value="T-42" />);
+      expect(
+        screen.getByText('T-42 · Implement edge-caching'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('renderTriggerLabel', () => {
+    const prefixOptions = [
+      { value: 'T-42', label: 'Implement edge-caching', prefix: 'T-42' },
+    ];
+
+    it('uses custom render when provided', () => {
+      render(
+        <Selector
+          options={prefixOptions}
+          value="T-42"
+          renderTriggerLabel={(opt) =>
+            'prefix' in opt && opt.prefix
+              ? `${opt.prefix}: ${opt.label}`
+              : opt.label
+          }
+        />,
+      );
+      expect(
+        screen.getByText('T-42: Implement edge-caching'),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to default format when not provided', () => {
       render(<Selector options={prefixOptions} value="T-42" />);
       expect(
         screen.getByText('T-42 · Implement edge-caching'),

--- a/packages/ds/src/components/Selector/Selector.tsx
+++ b/packages/ds/src/components/Selector/Selector.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  useCallback,
   useId,
   useRef,
   type HTMLAttributes,
@@ -55,7 +56,8 @@ export interface SelectorProps extends HTMLAttributes<HTMLDivElement> {
   emptyState?: ReactNode;
   action?: SelectorAction;
   dropdownAlign?: DropdownAlign;
-  size?: 'sm' | 'md';
+  variant?: 'default' | 'inline';
+  renderTriggerLabel?: (option: SelectorOption) => ReactNode;
 }
 
 function focusSibling(current: EventTarget, direction: 'next' | 'prev') {
@@ -77,13 +79,14 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
       onValueChange,
       open = false,
       onOpenChange,
-      placeholder = 'Select…',
+      placeholder = 'Select\u2026',
       triggerPrefix,
       header,
       emptyState,
       action,
       dropdownAlign = 'stretch',
-      size = 'md',
+      variant = 'default',
+      renderTriggerLabel: renderTriggerLabelProp,
       className,
       'aria-label': ariaLabel,
       ...rest
@@ -96,7 +99,22 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
     const listboxId = `${rest.id ?? reactId}-listbox`;
     const hasIcons = options.some((o) => o.icon !== undefined);
     const hasPrefixes = options.some((o) => o.prefix !== undefined);
-    const isSmall = size === 'sm';
+    const isInline = variant === 'inline';
+
+    const handleDropdownMount = useCallback((el: HTMLDivElement | null) => {
+      if (!el) return;
+      const selectedEl = el.querySelector<HTMLElement>(
+        '[aria-selected="true"]',
+      );
+      if (selectedEl) selectedEl.scrollIntoView?.({ block: 'nearest' });
+
+      const activeElement = el.ownerDocument.activeElement;
+      if (activeElement && el.contains(activeElement)) return;
+
+      const headerInput = el.querySelector<HTMLElement>('input, textarea');
+      const first = el.querySelector<HTMLElement>('[role="option"]');
+      (headerInput ?? selectedEl ?? first)?.focus();
+    }, []);
 
     const handleTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
       if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
@@ -138,8 +156,9 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
 
     function renderTriggerLabel() {
       if (!selected) return placeholder;
+      if (renderTriggerLabelProp) return renderTriggerLabelProp(selected);
       if (hasPrefixes && selected.prefix) {
-        return `${selected.prefix} · ${selected.label}`;
+        return `${selected.prefix} \u00b7 ${selected.label}`;
       }
       return selected.label;
     }
@@ -180,9 +199,11 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
         <button
           ref={triggerRef}
           type="button"
-          className={cn(styles.trigger, isSmall && styles.iconTrigger)}
+          className={cn(styles.trigger, isInline && styles.inlineTrigger)}
           aria-haspopup="listbox"
           aria-expanded={open}
+          aria-controls={open ? listboxId : undefined}
+          aria-label={ariaLabel}
           onClick={() => onOpenChange?.(!open)}
           onKeyDown={handleTriggerKeyDown}
         >
@@ -205,14 +226,15 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
           )}
           <span className={styles.label}>{renderTriggerLabel()}</span>
           <Icon
-            name={isSmall ? 'expand_more' : 'unfold_more'}
-            size={isSmall ? 'sm' : 'md'}
+            name={isInline ? 'expand_more' : 'unfold_more'}
+            size={isInline ? 'sm' : 'md'}
             className={styles.chevron}
           />
         </button>
 
         {open && (
           <div
+            ref={handleDropdownMount}
             className={cn(
               styles.dropdown,
               dropdownAlign === 'end' && styles.dropdownEnd,
@@ -233,11 +255,6 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
                 return (
                   <div
                     key={option.value}
-                    ref={
-                      isSelected
-                        ? (el) => el?.scrollIntoView?.({ block: 'nearest' })
-                        : undefined
-                    }
                     role="option"
                     tabIndex={0}
                     aria-selected={isSelected}
@@ -256,7 +273,7 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
                     {isSelected && (
                       <Icon
                         name="check_circle"
-                        size={isSmall ? 'sm' : 'md'}
+                        size={isInline ? 'sm' : 'md'}
                         className={styles.checkIcon}
                       />
                     )}
@@ -269,7 +286,10 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
                 <button
                   type="button"
                   className={styles.action}
-                  onClick={action.onClick}
+                  onClick={() => {
+                    action.onClick();
+                    onOpenChange?.(false);
+                  }}
                 >
                   <Icon name={action.icon} size="sm" />
                   <span>{action.label}</span>

--- a/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { Sidebar } from './Sidebar';
 import { Selector } from '../Selector';
 import { NavItem } from '../NavItem';
 import { Avatar } from '../Avatar';
 import { SectionHeader } from '../SectionHeader';
-import { useClickOutside } from '../../hooks/useClickOutside';
+import { useSelectorState } from '../../hooks/useSelector';
 
 const projects = [
   { value: 'eng-core', label: 'Engineering Core' },
@@ -40,11 +40,8 @@ type Story = StoryObj<typeof Sidebar>;
 
 function DefaultRender() {
   const [project, setProject] = useState('eng-core');
-  const [open, setOpen] = useState(false);
   const [activeNav, setActiveNav] = useState('tasks');
-  const selectorRef = useRef<HTMLDivElement>(null);
-  const closeSelector = useCallback(() => setOpen(false), []);
-  useClickOutside(selectorRef, closeSelector, open);
+  const { ref, open, onOpenChange } = useSelectorState();
   const avatar = avatars[project];
   const navClick = (id: string) => (e: React.MouseEvent) => {
     e.preventDefault();
@@ -54,12 +51,12 @@ function DefaultRender() {
     <Sidebar
       header={
         <Selector
-          ref={selectorRef}
+          ref={ref}
           options={projects}
           value={project}
           onValueChange={setProject}
           open={open}
-          onOpenChange={setOpen}
+          onOpenChange={onOpenChange}
           triggerPrefix={
             <Avatar initial={avatar.initial} aria-label={avatar.label} />
           }

--- a/packages/ds/src/components/TaskDrawer/TaskDrawer.stories.tsx
+++ b/packages/ds/src/components/TaskDrawer/TaskDrawer.stories.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useRef, useState } from 'react';
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent, waitFor } from 'storybook/test';
-import { useClickOutside } from '../../hooks/useClickOutside';
+import { useSelectorGroup } from '../../hooks/useSelector';
 import { Drawer } from '../Drawer';
 import { TaskDrawer, TaskDrawerField, TaskDrawerSection } from './TaskDrawer';
 import { PropertyRow } from '../PropertyRow';
@@ -95,27 +95,20 @@ function DefaultRender() {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [priority, setPriority] = useState('high');
-  const [priorityOpen, setPriorityOpen] = useState(false);
-  const priorityRef = useRef<HTMLDivElement>(null);
-  const closePriority = useCallback(() => setPriorityOpen(false), []);
-  useClickOutside(priorityRef, closePriority, priorityOpen);
-
   const [linkedTicket, setLinkedTicket] = useState<string | undefined>(
     undefined,
   );
-  const [ticketOpen, setTicketOpen] = useState(false);
-  const ticketRef = useRef<HTMLDivElement>(null);
-  const closeTicket = useCallback(() => setTicketOpen(false), []);
-  useClickOutside(ticketRef, closeTicket, ticketOpen);
-
-  const openPriority = (v: boolean) => {
-    setPriorityOpen(v);
-    if (v) setTicketOpen(false);
-  };
-  const openTicket = (v: boolean) => {
-    setTicketOpen(v);
-    if (v) setPriorityOpen(false);
-  };
+  const selectors = useSelectorGroup('priority', 'ticket');
+  const {
+    ref: priorityRef,
+    open: priorityOpen,
+    onOpenChange: onPriorityChange,
+  } = selectors.priority;
+  const {
+    ref: ticketRef,
+    open: ticketOpen,
+    onOpenChange: onTicketChange,
+  } = selectors.ticket;
   const [ticketQuery, setTicketQuery] = useState('');
 
   return (
@@ -175,9 +168,9 @@ function DefaultRender() {
                 value={priority}
                 onValueChange={setPriority}
                 open={priorityOpen}
-                onOpenChange={openPriority}
+                onOpenChange={onPriorityChange}
                 dropdownAlign="end"
-                size="sm"
+                variant="inline"
                 aria-label="Select priority"
               />
             </PropertyRow>
@@ -204,7 +197,7 @@ function DefaultRender() {
                   setTicketQuery('');
                 }}
                 open={ticketOpen}
-                onOpenChange={openTicket}
+                onOpenChange={onTicketChange}
                 placeholder="Search ticket..."
                 header={
                   <SearchInput
@@ -214,7 +207,7 @@ function DefaultRender() {
                     size="sm"
                   />
                 }
-                size="sm"
+                variant="inline"
                 dropdownAlign="end"
                 action={{
                   label: 'Create new ticket',

--- a/packages/ds/src/hooks/useSelector.test.ts
+++ b/packages/ds/src/hooks/useSelector.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSelectorState, useSelectorGroup } from './useSelector';
+
+function fireMouseDown(target: EventTarget) {
+  target.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+}
+
+describe('useSelectorState', () => {
+  it('starts closed', () => {
+    const { result } = renderHook(() => useSelectorState());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('returns a ref object', () => {
+    const { result } = renderHook(() => useSelectorState());
+    expect(result.current.ref).toHaveProperty('current');
+  });
+
+  it('opens when onOpenChange is called with true', () => {
+    const { result } = renderHook(() => useSelectorState());
+    act(() => result.current.onOpenChange(true));
+    expect(result.current.open).toBe(true);
+  });
+
+  it('closes when onOpenChange is called with false', () => {
+    const { result } = renderHook(() => useSelectorState());
+    act(() => result.current.onOpenChange(true));
+    act(() => result.current.onOpenChange(false));
+    expect(result.current.open).toBe(false);
+  });
+
+  it('closes on click outside when open', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const { result } = renderHook(() => useSelectorState());
+
+    // Attach the ref
+    (
+      result.current.ref as React.MutableRefObject<HTMLDivElement | null>
+    ).current = el;
+    act(() => result.current.onOpenChange(true));
+
+    act(() => fireMouseDown(document.body));
+    expect(result.current.open).toBe(false);
+
+    document.body.removeChild(el);
+  });
+
+  it('does not close on click inside when open', () => {
+    const el = document.createElement('div');
+    document.body.appendChild(el);
+    const { result } = renderHook(() => useSelectorState());
+
+    (
+      result.current.ref as React.MutableRefObject<HTMLDivElement | null>
+    ).current = el;
+    act(() => result.current.onOpenChange(true));
+
+    act(() => fireMouseDown(el));
+    expect(result.current.open).toBe(true);
+
+    document.body.removeChild(el);
+  });
+});
+
+describe('useSelectorGroup', () => {
+  it('returns an entry for each key', () => {
+    const { result } = renderHook(() => useSelectorGroup('a', 'b', 'c'));
+    expect(result.current).toHaveProperty('a');
+    expect(result.current).toHaveProperty('b');
+    expect(result.current).toHaveProperty('c');
+  });
+
+  it('all start closed', () => {
+    const { result } = renderHook(() => useSelectorGroup('a', 'b'));
+    expect(result.current.a.open).toBe(false);
+    expect(result.current.b.open).toBe(false);
+  });
+
+  it('opening one closes the other', () => {
+    const { result } = renderHook(() => useSelectorGroup('a', 'b'));
+    act(() => result.current.a.onOpenChange(true));
+    expect(result.current.a.open).toBe(true);
+    expect(result.current.b.open).toBe(false);
+
+    act(() => result.current.b.onOpenChange(true));
+    expect(result.current.a.open).toBe(false);
+    expect(result.current.b.open).toBe(true);
+  });
+
+  it('closing the open one leaves all closed', () => {
+    const { result } = renderHook(() => useSelectorGroup('a', 'b'));
+    act(() => result.current.a.onOpenChange(true));
+    act(() => result.current.a.onOpenChange(false));
+    expect(result.current.a.open).toBe(false);
+    expect(result.current.b.open).toBe(false);
+  });
+
+  it('closes on click outside', () => {
+    const elA = document.createElement('div');
+    document.body.appendChild(elA);
+    const { result } = renderHook(() => useSelectorGroup('a', 'b'));
+
+    act(() => result.current.a.ref(elA));
+    act(() => result.current.a.onOpenChange(true));
+
+    act(() => fireMouseDown(document.body));
+    expect(result.current.a.open).toBe(false);
+
+    document.body.removeChild(elA);
+  });
+
+  it('does not close on click inside the open selector', () => {
+    const elA = document.createElement('div');
+    document.body.appendChild(elA);
+    const { result } = renderHook(() => useSelectorGroup('a', 'b'));
+
+    act(() => result.current.a.ref(elA));
+    act(() => result.current.a.onOpenChange(true));
+
+    act(() => fireMouseDown(elA));
+    expect(result.current.a.open).toBe(true);
+
+    document.body.removeChild(elA);
+  });
+});

--- a/packages/ds/src/hooks/useSelector.ts
+++ b/packages/ds/src/hooks/useSelector.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useClickOutside } from './useClickOutside';
+
+export interface UseSelectorStateReturn {
+  readonly ref: React.RefObject<HTMLDivElement | null>;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+export function useSelectorState(): UseSelectorStateReturn {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const close = useCallback(() => setOpen(false), []);
+  useClickOutside(ref, close, open);
+  return { ref, open, onOpenChange: setOpen };
+}
+
+export interface SelectorGroupEntry {
+  readonly ref: (el: HTMLDivElement | null) => void;
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Manages mutual exclusion for multiple `Selector` components — only one
+ * can be open at a time. Opening one (via mouse or keyboard) automatically
+ * closes any other. Includes click-outside detection.
+ *
+ * Use `useSelectorState` instead when selectors are independent and may open
+ * simultaneously.
+ *
+ * @example
+ * ```tsx
+ * const selectors = useSelectorGroup('priority', 'ticket', 'status');
+ * const { ref, open, onOpenChange } = selectors.priority;
+ *
+ * <Selector ref={ref} open={open} onOpenChange={onOpenChange} ... />
+ * ```
+ */
+export function useSelectorGroup<K extends string>(
+  ...keys: K[]
+): Record<K, SelectorGroupEntry> {
+  const [openKey, setOpenKey] = useState<K | null>(null);
+  const elements = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    if (!openKey) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const el = elements.current[openKey];
+      if (el && !el.contains(e.target as Node)) {
+        setOpenKey(null);
+      }
+    };
+    document.addEventListener('mousedown', onMouseDown);
+    return () => document.removeEventListener('mousedown', onMouseDown);
+  }, [openKey]);
+
+  const result = {} as Record<K, SelectorGroupEntry>;
+  for (const key of keys) {
+    result[key] = {
+      ref: (el: HTMLDivElement | null) => {
+        elements.current[key] = el;
+      },
+      open: openKey === key,
+      onOpenChange: (v: boolean) => setOpenKey(v ? key : null),
+    };
+  }
+  return result;
+}

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -100,6 +100,12 @@ export {
 
 export { useClickOutside } from './hooks/useClickOutside';
 export { useFocusTrap } from './hooks/useFocusTrap';
+export {
+  useSelectorState,
+  useSelectorGroup,
+  type UseSelectorStateReturn,
+  type SelectorGroupEntry,
+} from './hooks/useSelector';
 
 export {
   colors,


### PR DESCRIPTION
## Refactor
  - useSelectorState hook → bundles open state, ref and click-outside into one call eliminating the 4-line       
  boilerplate every consumer repeated                                                                                
  - useSelectorGroup hook →  manages mutual exclusion for N co-located selectors (only one open at a time), replacing
  manual wiring for consumers                                                                                   
  - A11y fixes  →aria-label and aria-controls on the trigger button
  - Focus management on open (header input preferred over options e.g searchable selector now focus on search instead on the first option when open ed)
  - scrollIntoView fires once on mount instead of every render
  - action button now closes the dropdown  
  - cleanup → size prop replaced with variant: 'default' | 'inline', better naming
  - new optional renderTriggerLabel for custom trigger formatting (backwards-compatible), removed weak .header > div CSS hack
  - Prefix alignment → option prefixes left-aligned 

<img width="1728" height="1085" alt="refactor-selector" src="https://github.com/user-attachments/assets/faaadd21-74df-4e85-af50-fd215aa0e760" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `Selector`’s public API (`size` -> `variant`) and dropdown open/close/focus behavior, which could subtly affect consumers’ layout and keyboard interactions.
> 
> **Overview**
> Refactors `Selector` usage by introducing `useSelectorState` (single selector with click-outside close) and `useSelectorGroup` (mutually exclusive selectors), updating Storybook compositions to remove repeated open/ref boilerplate and enforce one-open-at-a-time where needed.
> 
> Updates `Selector` itself with improved accessibility and interaction: adds `aria-controls`/`aria-label` wiring, focuses header input/selected option on open, scrolls the selected option into view only on mount, and closes the dropdown when the action button is clicked.
> 
> Cleans up styling and API: replaces `size` with `variant: 'default' | 'inline'`, renames related CSS (`.iconTrigger` -> `.inlineTrigger`), adjusts header/prefix alignment, adds optional `renderTriggerLabel`, expands tests for the new behaviors, and exports the new hooks from `index.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3208da18237485acb7ddad352803ae231201a996. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->