### PR TITLE
Refactor/components/task section and selector

### DIFF
--- a/packages/ds/e2e/pages/tasks.spec.ts
+++ b/packages/ds/e2e/pages/tasks.spec.ts
@@ -158,15 +158,18 @@ test.describe('Tasks page — order by', () => {
   });
 
   test('sorting by due date shows latest date first', async ({ page }) => {
+    const activeSection = page.getByRole('group', { name: 'Active Tasks' });
+    const times = activeSection.getByRole('time');
+
+    // Capture second item before sort — it will change when sort applies
+    const preSortSecond = await times.nth(1).getAttribute('datetime');
+
     const sortButton = page.getByRole('button', { name: 'Sort tasks by' });
     await sortButton.click();
     await page.getByRole('option', { name: 'Due date' }).click();
 
-    const activeSection = page.locator('details', { hasText: 'Active Tasks' });
-    const times = activeSection.getByRole('time');
-
-    // Web-first wait: ensure the sort has flushed before reading all values
-    await expect(times.first()).toHaveAttribute('datetime', '2026-04-03');
+    // Web-first wait: second date changes after sort flushes
+    await expect(times.nth(1)).not.toHaveAttribute('datetime', preSortSecond ?? '');
 
     const dateTimes = await times.evaluateAll((els) =>
       els.map((el) => el.getAttribute('datetime')),

--- a/packages/ds/e2e/pages/tasks.spec.ts
+++ b/packages/ds/e2e/pages/tasks.spec.ts
@@ -134,6 +134,51 @@ test.describe('Tasks page — selector mutual exclusion', () => {
   });
 });
 
+test.describe('Tasks page — order by', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadStory(page);
+  });
+
+  test('sort selector does not collapse the section', async ({ page }) => {
+    const sortButton = page.getByRole('button', { name: 'Sort tasks by' });
+    await sortButton.click();
+    await expect(page.getByRole('listbox', { name: 'Sort tasks by' })).toBeVisible();
+
+    // Close by clicking the trigger again — section should stay open
+    await sortButton.click();
+    await expect(page.getByText('Refactor Kubernetes')).toBeVisible();
+  });
+
+  test('sorting by priority shows critical before medium', async ({ page }) => {
+    const priorities = page.getByText(/^(critical|high|medium|low)$/i);
+    const labels = await priorities.allTextContents();
+    const criticalIndex = labels.findIndex((l) => l.toLowerCase() === 'critical');
+    const mediumIndex = labels.findIndex((l) => l.toLowerCase() === 'medium');
+    expect(criticalIndex).toBeLessThan(mediumIndex);
+  });
+
+  test('sorting by due date shows latest date first', async ({ page }) => {
+    const sortButton = page.getByRole('button', { name: 'Sort tasks by' });
+    await sortButton.click();
+    await page.getByRole('option', { name: 'Due date' }).click();
+
+    const activeSection = page.locator('details', { hasText: 'Active Tasks' });
+    const times = activeSection.getByRole('time');
+
+    // Web-first wait: ensure the sort has flushed before reading all values
+    await expect(times.first()).toHaveAttribute('datetime', '2026-04-03');
+
+    const dateTimes = await times.evaluateAll((els) =>
+      els.map((el) => el.getAttribute('datetime')),
+    );
+    expect(dateTimes.length).toBeGreaterThan(1);
+    const isSortedDesc = dateTimes.every(
+      (d, i) => i === 0 || (d ?? '') <= (dateTimes[i - 1] ?? ''),
+    );
+    expect(isSortedDesc).toBe(true);
+  });
+});
+
 test.describe('Tasks page — focus trap', () => {
   test('Tab cycles within drawer and Escape returns focus to trigger', async ({ page }) => {
     await loadStory(page);

--- a/packages/ds/src/components/Avatar/Avatar.module.css
+++ b/packages/ds/src/components/Avatar/Avatar.module.css
@@ -9,6 +9,12 @@
   user-select: none;
 }
 
+.sm {
+  width: var(--ds-space-avatar-size-sm);
+  height: var(--ds-space-avatar-size-sm);
+  font-size: var(--ds-text-avatar-sm-initial-font-size);
+}
+
 .project {
   font-size: var(--ds-text-avatar-initial-font-size);
   font-weight: var(--ds-text-avatar-initial-font-weight);

--- a/packages/ds/src/components/Avatar/Avatar.module.css
+++ b/packages/ds/src/components/Avatar/Avatar.module.css
@@ -9,12 +9,6 @@
   user-select: none;
 }
 
-.sm {
-  width: var(--ds-space-avatar-size-sm);
-  height: var(--ds-space-avatar-size-sm);
-  font-size: var(--ds-text-avatar-sm-initial-font-size);
-}
-
 .project {
   font-size: var(--ds-text-avatar-initial-font-size);
   font-weight: var(--ds-text-avatar-initial-font-weight);

--- a/packages/ds/src/components/Selector/Selector.stories.tsx
+++ b/packages/ds/src/components/Selector/Selector.stories.tsx
@@ -4,6 +4,11 @@ import { Selector, type SelectorProps } from './Selector';
 import { Avatar } from '../Avatar';
 import { SearchInput } from '../SearchInput';
 import { useSelectorState } from '../../hooks/useSelector';
+import {
+  orderByLabelStyle,
+  orderByPrefixStyle,
+  orderByValueStyle,
+} from '../../stories/helpers/orderByStyles';
 
 const projects = [
   { value: 'eng-core', label: 'Engineering Core' },
@@ -343,4 +348,45 @@ function AvatarOptionsRender() {
 
 export const AvatarOptions: Story = {
   render: () => <AvatarOptionsRender />,
+};
+
+function OrderByRender() {
+  const options = [
+    { value: 'priority', label: 'Priority' },
+    { value: 'due-date', label: 'Due date' },
+  ];
+  const [value, setValue] = useState('priority');
+  const { ref, open, onOpenChange } = useSelectorState();
+  return (
+    <Selector
+      ref={ref}
+      options={options}
+      value={value}
+      onValueChange={setValue}
+      open={open}
+      onOpenChange={onOpenChange}
+      variant="inline"
+      renderTriggerLabel={(opt) => (
+        <span style={orderByLabelStyle}>
+          <span style={orderByPrefixStyle}>Order by: </span>
+          <span style={orderByValueStyle}>{opt.label}</span>
+        </span>
+      )}
+      renderOptionIndicator={() => null}
+      aria-label="Sort tasks by"
+    />
+  );
+}
+
+export const OrderBy: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        style={{ display: 'flex', justifyContent: 'center', padding: '24px' }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => <OrderByRender />,
 };

--- a/packages/ds/src/components/TaskRow/TaskRow.module.css
+++ b/packages/ds/src/components/TaskRow/TaskRow.module.css
@@ -160,5 +160,5 @@
 }
 
 .completed .priority {
-  filter: saturate(0.3);
+  filter: var(--ds-effect-completed-saturate);
 }

--- a/packages/ds/src/components/TaskRow/TaskRow.stories.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.stories.tsx
@@ -174,6 +174,7 @@ export const CompactList: Story = {
   },
   args: {
     title: 'Implement OAuth2 provider',
+    refId: 'T-104',
   },
   render: () => (
     <ul
@@ -222,6 +223,7 @@ export const TaskList: Story = {
   parameters: { viewport: { options: desktopViewports } },
   args: {
     title: 'Fix authentication timeout on mobile devices',
+    refId: 'ENG-902',
   },
   render: () => (
     <ul style={{ listStyle: 'none', margin: 0, padding: 0 }}>

--- a/packages/ds/src/components/TaskRow/TaskRow.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.tsx
@@ -107,11 +107,9 @@ export const TaskRow = forwardRef<HTMLDivElement, TaskRowProps>(
         </div>
         <div className={styles.info}>
           <div className={styles.ticket}>
-            {refId && <TicketId>{refId}</TicketId>}
+            <TicketId>{refId}</TicketId>
           </div>
-          {refId && date && (
-            <span className={styles.separator} aria-hidden="true" />
-          )}
+          {date && <span className={styles.separator} aria-hidden="true" />}
           <div className={styles.date}>
             {date && (
               <DateCell

--- a/packages/ds/src/components/TaskSection/TaskSection.module.css
+++ b/packages/ds/src/components/TaskSection/TaskSection.module.css
@@ -1,5 +1,6 @@
 .taskSection {
   border: none;
+  position: relative;
 }
 
 .summary {
@@ -39,6 +40,15 @@
   text-transform: var(--ds-text-section-header-text-transform);
   line-height: var(--ds-text-section-header-line-height);
   color: var(--ds-color-text-secondary);
+}
+
+.trailing {
+  position: absolute;
+  top: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  height: var(--ds-text-section-header-line-height);
 }
 
 .content {

--- a/packages/ds/src/components/TaskSection/TaskSection.module.css
+++ b/packages/ds/src/components/TaskSection/TaskSection.module.css
@@ -1,5 +1,8 @@
 .taskSection {
   border: none;
+}
+
+.wrapper {
   position: relative;
 }
 

--- a/packages/ds/src/components/TaskSection/TaskSection.stories.tsx
+++ b/packages/ds/src/components/TaskSection/TaskSection.stories.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import { TaskSection } from './TaskSection';
+import { Selector } from '../Selector';
+import { useSelectorState } from '../../hooks/useSelector';
 
 const meta = {
   title: 'Components/TaskSection',
@@ -36,6 +39,51 @@ export const Closed: Story = {
     badgeVariant: 'done',
     children: <p>Completed tasks would appear here.</p>,
   },
+};
+
+const sortOptions = [
+  { value: 'priority', label: 'Priority' },
+  { value: 'due-date', label: 'Due date' },
+  { value: 'recently-updated', label: 'Recently updated' },
+];
+
+function WithOrderByRender() {
+  const [sort, setSort] = useState('priority');
+  const { ref, open, onOpenChange } = useSelectorState();
+  const selected = sortOptions.find((o) => o.value === sort);
+
+  return (
+    <TaskSection
+      title="Active Tasks"
+      count={5}
+      badgeVariant="progress"
+      open
+      trailing={
+        <Selector
+          ref={ref}
+          variant="inline"
+          dropdownAlign="end"
+          options={sortOptions}
+          value={sort}
+          onValueChange={setSort}
+          open={open}
+          onOpenChange={onOpenChange}
+          renderTriggerLabel={() => (
+            <span>Order by: {selected?.label ?? 'Select'}</span>
+          )}
+          renderOptionIndicator={() => null}
+          aria-label="Sort tasks by"
+        />
+      }
+    >
+      <p>Task rows would appear here, sorted by {sort}.</p>
+    </TaskSection>
+  );
+}
+
+export const WithOrderBy: Story = {
+  args: { title: 'Active Tasks' },
+  render: () => <WithOrderByRender />,
 };
 
 export const WithoutCount: Story = {

--- a/packages/ds/src/components/TaskSection/TaskSection.test.tsx
+++ b/packages/ds/src/components/TaskSection/TaskSection.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { TaskSection } from './TaskSection';
 
 describe('TaskSection', () => {
@@ -67,5 +68,26 @@ describe('TaskSection', () => {
       </TaskSection>,
     );
     expect(container.querySelector('details')).toHaveClass('custom');
+  });
+
+  it('renders trailing slot content', () => {
+    render(
+      <TaskSection title="ACTIVE TASKS" trailing={<button>Sort</button>}>
+        <p>Content</p>
+      </TaskSection>,
+    );
+    expect(screen.getByRole('button', { name: 'Sort' })).toBeInTheDocument();
+  });
+
+  it('trailing click does not toggle section', async () => {
+    const { container } = render(
+      <TaskSection title="ACTIVE TASKS" open trailing={<button>Sort</button>}>
+        <p>Content</p>
+      </TaskSection>,
+    );
+    const details = container.querySelector('details');
+    expect(details).toHaveAttribute('open');
+    await userEvent.click(screen.getByRole('button', { name: 'Sort' }));
+    expect(details).toHaveAttribute('open');
   });
 });

--- a/packages/ds/src/components/TaskSection/TaskSection.tsx
+++ b/packages/ds/src/components/TaskSection/TaskSection.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type DetailsHTMLAttributes } from 'react';
+import { forwardRef, type DetailsHTMLAttributes, type ReactNode } from 'react';
 import { Icon } from '../Icon';
 import { Badge } from '../Badge';
 import { cn } from '../../utils/cn';
@@ -10,17 +10,30 @@ export interface TaskSectionProps extends DetailsHTMLAttributes<HTMLDetailsEleme
   title: string;
   count?: number;
   badgeVariant?: BadgeVariant;
+  trailing?: ReactNode;
 }
 
 export const TaskSection = forwardRef<HTMLDetailsElement, TaskSectionProps>(
   (
-    { title, count, badgeVariant = 'default', className, children, ...rest },
+    {
+      title,
+      count,
+      badgeVariant = 'default',
+      trailing,
+      className,
+      children,
+      ...rest
+    },
     ref,
   ) => {
-    return (
+    const details = (
       <details
         ref={ref}
-        className={cn(styles.taskSection, className)}
+        className={cn(
+          styles.taskSection,
+          !!trailing && styles.hasTrailing,
+          className,
+        )}
         {...rest}
       >
         <summary className={styles.summary}>
@@ -30,6 +43,15 @@ export const TaskSection = forwardRef<HTMLDetailsElement, TaskSectionProps>(
         </summary>
         <div className={styles.content}>{children}</div>
       </details>
+    );
+
+    if (!trailing) return details;
+
+    return (
+      <div className={styles.wrapper}>
+        {details}
+        <div className={styles.trailing}>{trailing}</div>
+      </div>
     );
   },
 );

--- a/packages/ds/src/components/TaskSection/TaskSection.tsx
+++ b/packages/ds/src/components/TaskSection/TaskSection.tsx
@@ -10,6 +10,8 @@ export interface TaskSectionProps extends DetailsHTMLAttributes<HTMLDetailsEleme
   title: string;
   count?: number;
   badgeVariant?: BadgeVariant;
+  /** Rendered outside `<details>` via absolute positioning.
+   *  The forwarded ref always points to the `<details>` element. */
   trailing?: ReactNode;
 }
 
@@ -29,11 +31,8 @@ export const TaskSection = forwardRef<HTMLDetailsElement, TaskSectionProps>(
     const details = (
       <details
         ref={ref}
-        className={cn(
-          styles.taskSection,
-          !!trailing && styles.hasTrailing,
-          className,
-        )}
+        className={cn(styles.taskSection, className)}
+        aria-label={title}
         {...rest}
       >
         <summary className={styles.summary}>

--- a/packages/ds/src/stories/helpers/orderByStyles.ts
+++ b/packages/ds/src/stories/helpers/orderByStyles.ts
@@ -1,0 +1,18 @@
+import type { CSSProperties } from 'react';
+
+export const orderByLabelStyle: CSSProperties = {
+  fontFamily: 'var(--ds-text-section-header-font-family)',
+  fontSize: 'var(--ds-text-section-header-font-size)',
+  letterSpacing: 'var(--ds-text-section-header-letter-spacing)',
+  textTransform: 'uppercase',
+  lineHeight: 'var(--ds-text-section-header-line-height)',
+};
+
+export const orderByPrefixStyle: CSSProperties = {
+  color: 'var(--ds-color-text-secondary)',
+  fontWeight: 'var(--ds-font-weight-medium)',
+};
+
+export const orderByValueStyle: CSSProperties = {
+  fontWeight: 'var(--ds-font-weight-extrabold)',
+};

--- a/packages/ds/src/stories/pages/TasksPage.stories.tsx
+++ b/packages/ds/src/stories/pages/TasksPage.stories.tsx
@@ -30,6 +30,11 @@ import {
 import { PropertyRow } from '../../components/PropertyRow';
 import { RecentTaskList } from '../../components/RecentTaskList';
 import type { RecentTaskItem } from '../../components/RecentTaskList';
+import {
+  orderByLabelStyle,
+  orderByPrefixStyle,
+  orderByValueStyle,
+} from '../helpers/orderByStyles';
 import styles from './TasksPage.module.css';
 
 type TaskItem = Pick<
@@ -48,7 +53,7 @@ const SEED_TASKS: readonly TaskItem[] = [
     refs: [{ label: 'architecture-spec-v2.md', variant: 'doc' }],
     priority: 'high',
     ticketId: 'ENG-902',
-    date: { label: 'Oct 28', dateTime: '2025-10-28' },
+    date: { label: 'Mar 28', dateTime: '2026-03-28' },
   },
   {
     id: 'TSK-2',
@@ -57,7 +62,7 @@ const SEED_TASKS: readonly TaskItem[] = [
     refs: [{ label: 'iam-policy-draft.json', variant: 'attachment' }],
     priority: 'medium',
     ticketId: 'INFRA-441',
-    date: { label: 'Oct 30', dateTime: '2025-10-30' },
+    date: { label: 'Mar 30', dateTime: '2026-03-30' },
   },
   {
     id: 'TSK-3',
@@ -66,7 +71,7 @@ const SEED_TASKS: readonly TaskItem[] = [
     refs: [{ label: 'incident artifact' }],
     priority: 'high',
     ticketId: 'OPS-112',
-    date: { label: 'Today', dateTime: '2025-11-01', urgent: true },
+    date: { label: 'Today', dateTime: '2026-04-03', urgent: true },
   },
   {
     id: 'TSK-4',
@@ -74,7 +79,7 @@ const SEED_TASKS: readonly TaskItem[] = [
     badge: { label: 'Todo', variant: 'todo' },
     refs: [{ label: 'pipeline-config.yaml', variant: 'attachment' }],
     priority: 'medium',
-    date: { label: 'Nov 2', dateTime: '2025-11-02' },
+    date: { label: 'Apr 1', dateTime: '2026-04-01' },
   },
   {
     id: 'TSK-5',
@@ -82,7 +87,7 @@ const SEED_TASKS: readonly TaskItem[] = [
     badge: { label: 'In Progress', variant: 'progress' },
     refs: [{ label: 'heap-dump-analysis' }],
     priority: 'critical',
-    date: { label: 'Today', dateTime: '2025-11-01', urgent: true },
+    date: { label: 'Today', dateTime: '2026-04-03', urgent: true },
   },
 ];
 
@@ -93,7 +98,7 @@ const SEED_COMPLETED: readonly TaskItem[] = [
     badge: { label: 'Done', variant: 'done' },
     priority: 'low',
     ticketId: 'SEC-22',
-    date: { label: 'Jan 12', dateTime: '2025-01-12' },
+    date: { label: 'Jan 12', dateTime: '2026-01-12' },
   },
 ];
 
@@ -200,6 +205,39 @@ function filterSearchResults(query: string): SearchPaletteGroup[] {
     .filter((group) => group.results.length > 0);
 }
 
+const sortOptions = [
+  { value: 'priority', label: 'Priority' },
+  { value: 'due-date', label: 'Due date' },
+];
+
+const PRIORITY_ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+function sortTasks(
+  tasks: readonly TaskItem[],
+  by: string,
+): readonly TaskItem[] {
+  const sorted = [...tasks];
+  switch (by) {
+    case 'priority':
+      return sorted.sort(
+        (a, b) =>
+          (PRIORITY_ORDER[a.priority ?? 'low'] ?? 4) -
+          (PRIORITY_ORDER[b.priority ?? 'low'] ?? 4),
+      );
+    case 'due-date':
+      return sorted.sort((a, b) =>
+        (b.date?.dateTime ?? '').localeCompare(a.date?.dateTime ?? ''),
+      );
+    default:
+      return sorted;
+  }
+}
+
 interface DrawerFormState {
   title: string;
   description: string;
@@ -237,6 +275,12 @@ function TasksPageRender({
     searchQuery.length > 0 ? filterSearchResults(searchQuery) : [];
 
   const [filterQuery, setFilterQuery] = useState('');
+  const [sortBy, setSortBy] = useState('priority');
+  const {
+    ref: sortRef,
+    open: sortOpen,
+    onOpenChange: onSortChange,
+  } = useSelectorState();
   const [completedIds, setCompletedIds] = useState<ReadonlySet<string>>(
     () =>
       new Set(
@@ -272,11 +316,14 @@ function TasksPageRender({
 
   const activeTasks = useMemo(() => {
     const q = filterQuery.toLowerCase();
-    return allTasks
+    const filtered = allTasks
       .filter((t) => !completedIds.has(t.id))
       .filter((t) => (q ? t.title.toLowerCase().includes(q) : true));
-  }, [allTasks, completedIds, filterQuery]);
+    return sortTasks(filtered, sortBy);
+  }, [allTasks, completedIds, filterQuery, sortBy]);
 
+  // Completed tasks are not sorted here — the consumer will usually want to
+  // apply a default sort like most-recently-completed-first.
   const completedTasks = useMemo(() => {
     const q = filterQuery.toLowerCase();
     return allTasks
@@ -482,6 +529,25 @@ function TasksPageRender({
                   count={activeTasks.length}
                   badgeVariant="progress"
                   open
+                  trailing={
+                    <Selector
+                      ref={sortRef}
+                      variant="inline"
+                      options={sortOptions}
+                      value={sortBy}
+                      onValueChange={setSortBy}
+                      open={sortOpen}
+                      onOpenChange={onSortChange}
+                      renderTriggerLabel={(opt) => (
+                        <span style={orderByLabelStyle}>
+                          <span style={orderByPrefixStyle}>Order by: </span>
+                          <span style={orderByValueStyle}>{opt.label}</span>
+                        </span>
+                      )}
+                      renderOptionIndicator={() => null}
+                      aria-label="Sort tasks by"
+                    />
+                  }
                 >
                   {activeTasks.map((task) => (
                     <TaskRow

--- a/packages/ds/src/tokens/effects.ts
+++ b/packages/ds/src/tokens/effects.ts
@@ -4,6 +4,7 @@ export const effects = {
   mutedOpacity: '0.4',
   disabledOpacity: '0.5',
   desaturate: 'grayscale(1)',
+  completedSaturate: 'saturate(0.3)',
 } as const;
 
 export type EffectToken = keyof typeof effects;


### PR DESCRIPTION

https://github.com/user-attachments/assets/747b68c7-324b-4e9f-b7ba-d95d06a66eba


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly Storybook/demo wiring, styling tokens, and additional tests; no backend or security-sensitive logic changes.
> 
> **Overview**
> Adds a *trailing slot* to `TaskSection` (absolutely positioned outside the `<details>` element) so controls like an inline selector can live in the section header without toggling/collapsing the section.
> 
> Updates the Tasks page Storybook to include an **“Order by”** selector that sorts active tasks by `priority` or `due-date`, introduces shared `orderByStyles`, and expands E2E/unit tests to cover sorting behavior and the non-collapsing header control interaction.
> 
> Small UI polish includes tokenizing the completed-row priority desaturation effect and ensuring `TaskRow` always renders the ticket id/separator consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af78701c8abf8ed051e77685f0d29ed189757c2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->