### PR TITLE
fix(drawer): restructure close button; add sidebar workspace info to …

### DIFF
--- a/packages/ds/e2e/pages/tasks.spec.ts
+++ b/packages/ds/e2e/pages/tasks.spec.ts
@@ -51,13 +51,19 @@ test.describe('Tasks page — drawer lifecycle', () => {
   });
 
   test('close button remains clickable after scrolling drawer content', async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 300 });
+    await page.setViewportSize({ width: 1280, height: 200 });
     await page.getByRole('button', { name: /new task/i }).click();
     const dialog = page.getByRole('dialog', { name: 'New task' });
     await expect(dialog).toBeVisible();
 
-    // Scroll the TaskDrawer body (the actual overflow container) via a bottom element
+    // Verify the form top is initially in view
+    await expect(dialog.getByLabel('Task title')).toBeInViewport();
+
+    // Scroll a bottom element into view to force the TaskDrawer body to scroll
     await dialog.getByText('Properties').scrollIntoViewIfNeeded();
+
+    // Confirm scroll actually happened — top of form is no longer in viewport
+    await expect(dialog.getByLabel('Task title')).not.toBeInViewport();
 
     // Close button should still be visible and clickable
     const closeButton = dialog.getByRole('button', { name: 'Close' });

--- a/packages/ds/e2e/pages/tasks.spec.ts
+++ b/packages/ds/e2e/pages/tasks.spec.ts
@@ -49,6 +49,23 @@ test.describe('Tasks page — drawer lifecycle', () => {
     await page.keyboard.press('Escape');
     await expect(dialog).not.toBeVisible();
   });
+
+  test('close button remains clickable after scrolling drawer content', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 300 });
+    await page.getByRole('button', { name: /new task/i }).click();
+    const dialog = page.getByRole('dialog', { name: 'New task' });
+    await expect(dialog).toBeVisible();
+
+    // Scroll the drawer content down
+    const content = dialog.locator('div').first();
+    await content.evaluate((el) => el.scrollTop = el.scrollHeight);
+
+    // Close button should still be visible and clickable
+    const closeButton = dialog.getByRole('button', { name: 'Close' });
+    await expect(closeButton).toBeVisible();
+    await closeButton.click();
+    await expect(dialog).not.toBeVisible();
+  });
 });
 
 test.describe('Tasks page — checkbox completion', () => {

--- a/packages/ds/e2e/pages/tasks.spec.ts
+++ b/packages/ds/e2e/pages/tasks.spec.ts
@@ -56,9 +56,8 @@ test.describe('Tasks page — drawer lifecycle', () => {
     const dialog = page.getByRole('dialog', { name: 'New task' });
     await expect(dialog).toBeVisible();
 
-    // Scroll the drawer content down
-    const content = dialog.locator('div').first();
-    await content.evaluate((el) => el.scrollTop = el.scrollHeight);
+    // Scroll the TaskDrawer body (the actual overflow container) via a bottom element
+    await dialog.getByText('Properties').scrollIntoViewIfNeeded();
 
     // Close button should still be visible and clickable
     const closeButton = dialog.getByRole('button', { name: 'Close' });

--- a/packages/ds/src/components/Drawer/Drawer.module.css
+++ b/packages/ds/src/components/Drawer/Drawer.module.css
@@ -62,8 +62,8 @@
 
 .closeButton {
   position: absolute;
-  top: var(--ds-space-drawer-close-button-inset);
-  right: var(--ds-space-drawer-close-button-inset);
+  top: var(--ds-space-drawer-close-button-inset-top);
+  right: var(--ds-space-drawer-close-button-inset-right);
   z-index: 1;
   display: flex;
   align-items: center;
@@ -84,10 +84,11 @@
 }
 
 .content {
+  position: relative;
   flex: 1;
   overflow-y: auto;
   height: 100%;
-  padding-top: var(--ds-space-icon-button-md-size);
+  padding-top: var(--ds-space-scale-sm);
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -98,7 +99,7 @@
 }
 
 @media (max-width: 480px) {
-  .panel {
+  .right {
     width: 100%;
   }
 }

--- a/packages/ds/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ds/src/components/Drawer/Drawer.stories.tsx
@@ -81,7 +81,7 @@ function SidebarContent() {
         </>
       }
     >
-      <SectionHeader title="Project Artifacts" />
+      <SectionHeader>Project Artifacts</SectionHeader>
       <NavItem
         icon="task_alt"
         label="Tasks"

--- a/packages/ds/src/components/Drawer/Drawer.tsx
+++ b/packages/ds/src/components/Drawer/Drawer.tsx
@@ -93,15 +93,17 @@ export const Drawer = forwardRef<HTMLDivElement, DrawerProps>(
           style={{ ...durationStyle, ...style }}
           {...rest}
         >
-          <button
-            type="button"
-            className={styles.closeButton}
-            aria-label={closeLabel}
-            onClick={onClose}
-          >
-            <Icon name="close" size="sm" />
-          </button>
-          <div className={styles.content}>{children}</div>
+          <div className={styles.content}>
+            <button
+              type="button"
+              className={styles.closeButton}
+              aria-label={closeLabel}
+              onClick={onClose}
+            >
+              <Icon name="close" size="sm" />
+            </button>
+            {children}
+          </div>
         </div>
       </div>,
       document.body,

--- a/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
@@ -93,7 +93,7 @@ function DefaultRender() {
         </>
       }
     >
-      <SectionHeader title="Project Artifacts" />
+      <SectionHeader>Project Artifacts</SectionHeader>
       <NavItem
         icon="task_alt"
         label="Tasks"

--- a/packages/ds/src/components/TaskDrawer/TaskDrawer.module.css
+++ b/packages/ds/src/components/TaskDrawer/TaskDrawer.module.css
@@ -2,8 +2,7 @@
   display: flex;
   flex-direction: column;
   width: var(--ds-space-drawer-width);
-  height: calc(100% + var(--ds-space-icon-button-md-size));
-  margin-top: calc(-1 * var(--ds-space-icon-button-md-size));
+  height: 100%;
 }
 
 .header {

--- a/packages/ds/src/stories/pages/TasksPage.module.css
+++ b/packages/ds/src/stories/pages/TasksPage.module.css
@@ -10,6 +10,7 @@
   flex-direction: column;
   min-height: 0;
   overflow: hidden;
+  border-left: 1px solid var(--ds-color-border-default);
 }
 
 .scrollArea {

--- a/packages/ds/src/stories/pages/TasksPage.stories.tsx
+++ b/packages/ds/src/stories/pages/TasksPage.stories.tsx
@@ -8,6 +8,7 @@ import { Selector } from '../../components/Selector';
 import { NavItem } from '../../components/NavItem';
 import { Avatar } from '../../components/Avatar';
 import { SectionHeader } from '../../components/SectionHeader';
+import { StatusDot } from '../../components/StatusDot';
 import { Header } from '../../components/Header';
 import { Breadcrumb } from '../../components/Breadcrumb';
 import { SearchInput } from '../../components/SearchInput';
@@ -381,18 +382,69 @@ function TasksPageRender({
     <div className={styles.shell}>
       <Sidebar
         header={
-          <Selector
-            ref={projectRef}
-            options={projects}
-            value={project}
-            onValueChange={setProject}
-            open={projectOpen}
-            onOpenChange={onProjectChange}
-            triggerPrefix={
-              <Avatar initial={avatar.initial} aria-label={avatar.label} />
-            }
-            action={{ label: 'Add project', icon: 'add', onClick: () => {} }}
-          />
+          <>
+            <Selector
+              ref={projectRef}
+              options={projects}
+              value={project}
+              onValueChange={setProject}
+              open={projectOpen}
+              onOpenChange={onProjectChange}
+              triggerPrefix={
+                <Avatar initial={avatar.initial} aria-label={avatar.label} />
+              }
+              action={{ label: 'Add project', icon: 'add', onClick: () => {} }}
+            />
+            <div style={{ marginTop: 'var(--ds-space-sidebar-section-gap)' }}>
+              <span
+                style={{
+                  fontFamily: 'var(--ds-text-section-header-font-family)',
+                  fontSize: 'var(--ds-text-section-header-font-size)',
+                  fontWeight: 'var(--ds-font-weight-medium)',
+                  letterSpacing: 'var(--ds-text-section-header-letter-spacing)',
+                  textTransform: 'uppercase' as const,
+                  color: 'var(--ds-color-text-secondary)',
+                }}
+              >
+                Active Workspace
+              </span>
+              <p
+                style={{
+                  margin: 'var(--ds-space-scale-sm) 0 var(--ds-space-scale-sm)',
+                  fontFamily: 'var(--ds-font-family-sans)',
+                  fontSize: 'var(--ds-text-page-title-font-size)',
+                  fontWeight: 'var(--ds-font-weight-bold)',
+                  color: 'var(--ds-color-text-primary)',
+                  lineHeight: 'var(--ds-text-page-title-line-height)',
+                }}
+              >
+                Project / {avatar.label}
+              </p>
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 'var(--ds-space-scale-sm)',
+                }}
+              >
+                <span
+                  style={{
+                    fontFamily: 'var(--ds-font-family-mono)',
+                    fontSize: 'var(--ds-text-section-header-font-size)',
+                    color: 'var(--ds-color-text-secondary)',
+                    letterSpacing: '0.05em',
+                    padding:
+                      'var(--ds-space-badge-padding-y) var(--ds-space-badge-padding-x)',
+                    borderRadius: 'var(--ds-radius-lg)',
+                    backgroundColor: 'var(--ds-color-border-default)',
+                  }}
+                >
+                  v4.1.0-alpha
+                </span>
+                <StatusDot variant="active" label="Healthy" />
+              </span>
+            </div>
+          </>
         }
         footer={
           <>
@@ -420,7 +472,7 @@ function TasksPageRender({
           </>
         }
       >
-        <SectionHeader title="Project Artifacts" />
+        <SectionHeader>Project Artifacts</SectionHeader>
         <NavItem
           icon="task_alt"
           label="Tasks"

--- a/packages/ds/src/tokens/spacing.ts
+++ b/packages/ds/src/tokens/spacing.ts
@@ -98,7 +98,8 @@ export const spacing = {
     groupHeaderPaddingY: '8px',
   },
   drawer: {
-    closeButtonInset: '12px',
+    closeButtonInsetTop: '3px',
+    closeButtonInsetRight: '3px',
     width: '480px',
   },
   taskDrawer: {


### PR DESCRIPTION


https://github.com/user-attachments/assets/1f85d409-0af6-401d-8610-967f587252b1




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Drawer` structure and spacing tokens, which can affect layout/scroll behavior across all drawer usages. Risk is mitigated by added Playwright coverage for the reported close-button/scroll regression.
> 
> **Overview**
> **Drawer UX fix:** Restructures `Drawer` so the close button is rendered inside the scrollable content container and adjusts CSS (new top/right inset tokens, `content` positioning/padding) to keep it visible/clickable when the drawer body scrolls.
> 
> **Story/demo updates:** Updates `SectionHeader` usage in stories to use children instead of a `title` prop, enhances the Tasks page story sidebar header with active-workspace info (version + `StatusDot`), and tweaks Tasks page styling (adds a left border) plus TaskDrawer sizing to avoid scroll/offset hacks.
> 
> **Coverage:** Adds a new Playwright e2e test ensuring the drawer close button remains clickable after scrolling the Tasks drawer content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ea213d484e0d87b747e3d1f8b395ac09a5e44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->