### PR TITLE
feat(bottom-tab-bar): add mobile bottom tab bar and require sidebar a…

### DIFF
--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.module.css
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.module.css
@@ -1,0 +1,20 @@
+.bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: var(--ds-z-bottom-tab-bar);
+  display: flex;
+  align-items: stretch;
+  height: calc(
+    var(--ds-space-bottom-tab-bar-height) + env(safe-area-inset-bottom)
+  );
+  padding-bottom: env(safe-area-inset-bottom);
+  background-color: var(--ds-color-surface-primary);
+  border-top: 1px solid var(--ds-color-border-default);
+}
+
+.bar > * {
+  flex: 1 1 0;
+  min-width: 0;
+}

--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.stories.tsx
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.stories.tsx
@@ -1,0 +1,178 @@
+import { useState, type CSSProperties } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { withDefaultViewport } from '../../../.storybook/decorators';
+import { mobileViewportOptions } from '../../../.storybook/preview';
+import { BottomTabBar, type BottomTabBarProps } from './BottomTabBar';
+import { Fab } from '../Fab';
+import { NavItem } from '../NavItem';
+import type { IconName } from '../../icons';
+
+const meta: Meta<typeof BottomTabBar> = {
+  title: 'Components/BottomTabBar',
+  component: BottomTabBar,
+  tags: ['autodocs'],
+  args: {
+    'aria-label': 'Main navigation',
+  },
+  decorators: [withDefaultViewport('mobile')],
+  parameters: {
+    layout: 'fullscreen',
+    viewport: { options: mobileViewportOptions },
+    docs: {
+      description: {
+        component:
+          'Fixed-bottom mobile navigation bar. Intended for mobile viewports only — consumers are responsible for conditionally mounting it (e.g. via a media query or a mobile layout route), since the component itself does not hide on larger screens. BottomTabBar and Sidebar are mutually exclusive per viewport: a page should render one or the other, not both, since they create parallel navigation landmarks and represent the same concept for different form factors. Designed to host 3–5 vertical NavItems; behavior with more tabs is shown in the ManyTabs story.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomTabBar>;
+
+interface Tab {
+  id: string;
+  icon: IconName;
+  activeIcon?: IconName;
+  label: string;
+}
+
+function InteractiveBar({
+  tabs,
+  ...args
+}: BottomTabBarProps & { tabs: readonly Tab[] }) {
+  const [activeId, setActiveId] = useState(tabs[0]?.id);
+  return (
+    <BottomTabBar {...args}>
+      {tabs.map((tab) => (
+        <NavItem
+          key={tab.id}
+          icon={tab.icon}
+          activeIcon={tab.activeIcon}
+          label={tab.label}
+          href={`#${tab.id}`}
+          orientation="vertical"
+          active={tab.id === activeId}
+          onClick={(e) => {
+            e.preventDefault();
+            setActiveId(tab.id);
+          }}
+        />
+      ))}
+    </BottomTabBar>
+  );
+}
+
+const defaultTabs: readonly Tab[] = [
+  {
+    id: 'tasks',
+    icon: 'task_alt',
+    activeIcon: 'check_circle',
+    label: 'Tasks',
+  },
+  {
+    id: 'tickets',
+    icon: 'confirmation_number',
+    activeIcon: 'confirmation_number_filled',
+    label: 'Tickets',
+  },
+  {
+    id: 'docs',
+    icon: 'description',
+    activeIcon: 'description_filled',
+    label: 'Docs',
+  },
+  {
+    id: 'more',
+    icon: 'more_horiz',
+    label: 'More',
+  },
+];
+
+const longLabelTabs: readonly Tab[] = [
+  {
+    id: 'notifications',
+    icon: 'task_alt',
+    activeIcon: 'check_circle',
+    label: 'Notifications',
+  },
+  {
+    id: 'tickets',
+    icon: 'confirmation_number',
+    activeIcon: 'confirmation_number_filled',
+    label: 'Support Tickets',
+  },
+  {
+    id: 'docs',
+    icon: 'description',
+    activeIcon: 'description_filled',
+    label: 'Documentation',
+  },
+  {
+    id: 'more',
+    icon: 'more_horiz',
+    label: 'More',
+  },
+];
+
+export const Default: Story = {
+  render: (args) => <InteractiveBar {...args} tabs={defaultTabs} />,
+};
+
+export const WithLongLabels: Story = {
+  render: (args) => <InteractiveBar {...args} tabs={longLabelTabs} />,
+};
+
+const manyTabs: readonly Tab[] = [
+  {
+    id: 'tasks',
+    icon: 'task_alt',
+    activeIcon: 'check_circle',
+    label: 'Tasks',
+  },
+  {
+    id: 'tickets',
+    icon: 'confirmation_number',
+    activeIcon: 'confirmation_number_filled',
+    label: 'Tickets',
+  },
+  {
+    id: 'docs',
+    icon: 'description',
+    activeIcon: 'description_filled',
+    label: 'Docs',
+  },
+  {
+    id: 'search',
+    icon: 'search',
+    label: 'Search',
+  },
+  {
+    id: 'settings',
+    icon: 'settings',
+    label: 'Settings',
+  },
+  {
+    id: 'more',
+    icon: 'more_horiz',
+    label: 'More',
+  },
+];
+
+export const ManyTabs: Story = {
+  render: (args) => <InteractiveBar {...args} tabs={manyTabs} />,
+};
+
+const fabOffsetOverride = {
+  '--ds-space-fab-bottom-offset':
+    'calc(var(--ds-space-bottom-tab-bar-height) + 24px)',
+} as CSSProperties;
+
+export const WithFab: Story = {
+  render: (args) => (
+    <div style={{ minHeight: '100vh', ...fabOffsetOverride }}>
+      <Fab aria-label="New task" />
+      <InteractiveBar {...args} tabs={defaultTabs} />
+    </div>
+  ),
+};

--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.stories.tsx
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.stories.tsx
@@ -165,7 +165,7 @@ export const ManyTabs: Story = {
 
 const fabOffsetOverride = {
   '--ds-space-fab-bottom-offset':
-    'calc(var(--ds-space-bottom-tab-bar-height) + 24px)',
+    'calc(var(--ds-space-bottom-tab-bar-height) + env(safe-area-inset-bottom) + 24px)',
 } as CSSProperties;
 
 export const WithFab: Story = {

--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.test.tsx
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { BottomTabBar } from './BottomTabBar';
+import { NavItem } from '../NavItem';
+
+describe('BottomTabBar', () => {
+  it('renders as a nav element with the given aria-label', () => {
+    render(
+      <BottomTabBar aria-label="Main navigation">
+        <NavItem
+          icon="task_alt"
+          label="Tasks"
+          href="/tasks"
+          orientation="vertical"
+        />
+      </BottomTabBar>,
+    );
+    const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+    expect(nav).toBeInTheDocument();
+    expect(nav.tagName).toBe('NAV');
+  });
+
+  it('renders children', () => {
+    render(
+      <BottomTabBar aria-label="Main navigation">
+        <NavItem
+          icon="task_alt"
+          label="Tasks"
+          href="/tasks"
+          orientation="vertical"
+        />
+        <NavItem
+          icon="description"
+          label="Docs"
+          href="/docs"
+          orientation="vertical"
+        />
+      </BottomTabBar>,
+    );
+    expect(screen.getByRole('link', { name: 'Tasks' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Docs' })).toBeInTheDocument();
+  });
+
+  it('forwards ref to the nav element', () => {
+    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    render(
+      <BottomTabBar ref={ref} aria-label="Main navigation">
+        <NavItem
+          icon="task_alt"
+          label="Tasks"
+          href="/tasks"
+          orientation="vertical"
+        />
+      </BottomTabBar>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('NAV');
+  });
+
+  it('merges custom className', () => {
+    render(
+      <BottomTabBar aria-label="Main navigation" className="custom">
+        <NavItem
+          icon="task_alt"
+          label="Tasks"
+          href="/tasks"
+          orientation="vertical"
+        />
+      </BottomTabBar>,
+    );
+    expect(screen.getByRole('navigation')).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes onto the nav', () => {
+    render(
+      <BottomTabBar aria-label="Main navigation" id="bottom-nav">
+        <NavItem
+          icon="task_alt"
+          label="Tasks"
+          href="/tasks"
+          orientation="vertical"
+        />
+      </BottomTabBar>,
+    );
+    expect(screen.getByRole('navigation')).toHaveAttribute('id', 'bottom-nav');
+  });
+});

--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.tsx
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.tsx
@@ -1,0 +1,22 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+import styles from './BottomTabBar.module.css';
+
+export interface BottomTabBarProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'aria-label'
+> {
+  'aria-label': string;
+}
+
+export const BottomTabBar = forwardRef<HTMLElement, BottomTabBarProps>(
+  ({ children, className, ...rest }, ref) => {
+    return (
+      <nav ref={ref} className={cn(styles.bar, className)} {...rest}>
+        {children}
+      </nav>
+    );
+  },
+);
+
+BottomTabBar.displayName = 'BottomTabBar';

--- a/packages/ds/src/components/BottomTabBar/index.ts
+++ b/packages/ds/src/components/BottomTabBar/index.ts
@@ -1,0 +1,1 @@
+export { BottomTabBar, type BottomTabBarProps } from './BottomTabBar';

--- a/packages/ds/src/components/Drawer/Drawer.stories.tsx
+++ b/packages/ds/src/components/Drawer/Drawer.stories.tsx
@@ -51,6 +51,7 @@ function SidebarContent() {
 
   return (
     <Sidebar
+      aria-label="Sidebar navigation"
       header={
         <Selector
           ref={ref}

--- a/packages/ds/src/components/Fab/Fab.module.css
+++ b/packages/ds/src/components/Fab/Fab.module.css
@@ -1,8 +1,8 @@
 .fab {
   position: fixed;
-  /* TODO: tokenize bottom offset when BottomTabBar is implemented */
-  bottom: var(--ds-space-fab-offset);
-  right: var(--ds-space-fab-offset);
+  /* Override on an ancestor when composing above BottomTabBar */
+  bottom: var(--ds-space-fab-bottom-offset);
+  right: var(--ds-space-fab-right-offset);
   z-index: var(--ds-z-fab);
 
   display: inline-flex;

--- a/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.stories.tsx
@@ -49,6 +49,7 @@ function DefaultRender() {
   };
   return (
     <Sidebar
+      aria-label="Sidebar navigation"
       header={
         <Selector
           ref={ref}

--- a/packages/ds/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.test.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from './Sidebar';
 describe('Sidebar', () => {
   it('renders an aside with navigation landmark', () => {
     render(
-      <Sidebar>
+      <Sidebar aria-label="Sidebar navigation">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -16,7 +16,7 @@ describe('Sidebar', () => {
 
   it('renders children inside a nav element', () => {
     render(
-      <Sidebar>
+      <Sidebar aria-label="Sidebar navigation">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -27,7 +27,10 @@ describe('Sidebar', () => {
 
   it('renders header when provided', () => {
     render(
-      <Sidebar header={<span>Header Content</span>}>
+      <Sidebar
+        aria-label="Sidebar navigation"
+        header={<span>Header Content</span>}
+      >
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -36,7 +39,7 @@ describe('Sidebar', () => {
 
   it('does not render header wrapper when header is not provided', () => {
     const { container } = render(
-      <Sidebar>
+      <Sidebar aria-label="Sidebar navigation">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -46,7 +49,10 @@ describe('Sidebar', () => {
 
   it('renders footer when provided', () => {
     render(
-      <Sidebar footer={<span>Footer Content</span>}>
+      <Sidebar
+        aria-label="Sidebar navigation"
+        footer={<span>Footer Content</span>}
+      >
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -55,7 +61,7 @@ describe('Sidebar', () => {
 
   it('does not render footer wrapper when footer is not provided', () => {
     const { container } = render(
-      <Sidebar>
+      <Sidebar aria-label="Sidebar navigation">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -66,7 +72,7 @@ describe('Sidebar', () => {
   it('forwards ref to aside element', () => {
     const ref = { current: null } as React.RefObject<HTMLElement | null>;
     render(
-      <Sidebar ref={ref}>
+      <Sidebar ref={ref} aria-label="Sidebar navigation">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -76,7 +82,7 @@ describe('Sidebar', () => {
 
   it('applies custom className', () => {
     render(
-      <Sidebar className="custom-class">
+      <Sidebar aria-label="Sidebar navigation" className="custom-class">
         <a href="/link">Link</a>
       </Sidebar>,
     );
@@ -86,7 +92,7 @@ describe('Sidebar', () => {
 
   it('spreads additional HTML attributes', () => {
     render(
-      <Sidebar data-testid="my-sidebar">
+      <Sidebar aria-label="Sidebar navigation" data-testid="my-sidebar">
         <a href="/link">Link</a>
       </Sidebar>,
     );

--- a/packages/ds/src/components/Sidebar/Sidebar.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.tsx
@@ -2,7 +2,11 @@ import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import { cn } from '../../utils/cn';
 import styles from './Sidebar.module.css';
 
-export interface SidebarProps extends HTMLAttributes<HTMLElement> {
+export interface SidebarProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'aria-label'
+> {
+  'aria-label': string;
   header?: ReactNode;
   footer?: ReactNode;
 }
@@ -10,12 +14,7 @@ export interface SidebarProps extends HTMLAttributes<HTMLElement> {
 export const Sidebar = forwardRef<HTMLElement, SidebarProps>(
   ({ header, footer, children, className, ...rest }, ref) => {
     return (
-      <aside
-        ref={ref}
-        aria-label="Sidebar navigation"
-        className={cn(styles.sidebar, className)}
-        {...rest}
-      >
+      <aside ref={ref} className={cn(styles.sidebar, className)} {...rest}>
         {header && <div className={styles.header}>{header}</div>}
         <nav className={styles.nav}>{children}</nav>
         {footer && <div className={styles.footer}>{footer}</div>}

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -74,6 +74,10 @@ export {
   type TaskRowDate,
 } from './components/TaskRow';
 export { Sidebar, type SidebarProps } from './components/Sidebar';
+export {
+  BottomTabBar,
+  type BottomTabBarProps,
+} from './components/BottomTabBar';
 export { Header, type HeaderProps } from './components/Header';
 export {
   FloatingSearch,

--- a/packages/ds/src/stories/pages/TasksPage.stories.tsx
+++ b/packages/ds/src/stories/pages/TasksPage.stories.tsx
@@ -381,6 +381,7 @@ function TasksPageRender({
   return (
     <div className={styles.shell}>
       <Sidebar
+        aria-label="Sidebar navigation"
         header={
           <>
             <Selector

--- a/packages/ds/src/tokens/spacing.ts
+++ b/packages/ds/src/tokens/spacing.ts
@@ -116,7 +116,11 @@ export const spacing = {
   },
   fab: {
     size: '48px',
-    offset: '24px',
+    rightOffset: '24px',
+    bottomOffset: '24px',
+  },
+  bottomTabBar: {
+    height: '64px',
   },
   columnWidths: {
     priority: '80px',

--- a/packages/ds/src/tokens/zIndex.ts
+++ b/packages/ds/src/tokens/zIndex.ts
@@ -1,5 +1,6 @@
 export const zIndex = {
   header: '30',
+  bottomTabBar: '32',
   fab: '35',
   dropdown: '40',
   overlay: '50',


### PR DESCRIPTION
…ria-label

https://github.com/user-attachments/assets/f45e6781-2380-4c77-a308-3c35be4dca7a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new fixed-position navigation component and changes `SidebarProps` to require an `aria-label`, which is a breaking API change for consumers and could affect layout/positioning (especially when combined with `Fab`).
> 
> **Overview**
> Adds a new `BottomTabBar` component for fixed-bottom **mobile navigation**, including styling (safe-area inset support), Storybook stories, and unit tests, and exports it from the design system entrypoint.
> 
> Makes `Sidebar`’s `aria-label` **required** (moving from an internal default to a required prop), updating stories/tests/usages accordingly.
> 
> Updates `Fab` positioning tokens and CSS to use separate `--ds-space-fab-bottom-offset`/`--ds-space-fab-right-offset`, and adds new spacing/z-index tokens (`bottomTabBar.height`, `zIndex.bottomTabBar`) to support composing `Fab` above the bottom tab bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b98e13583f81d4ff11989c2bb33ab5d376620c0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->