### PR TITLE
feat(section-header): add subtitle and headingLevel props

### DIFF
--- a/packages/ds/src/components/SectionHeader/SectionHeader.module.css
+++ b/packages/ds/src/components/SectionHeader/SectionHeader.module.css
@@ -1,10 +1,28 @@
 .sectionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-scale-xs);
+}
+
+.title {
   font-size: var(--ds-text-section-header-font-size);
   font-family: var(--ds-text-section-header-font-family);
   font-weight: var(--ds-text-section-header-font-weight);
   letter-spacing: var(--ds-text-section-header-letter-spacing);
   text-transform: var(--ds-text-section-header-text-transform);
   line-height: var(--ds-text-section-header-line-height);
+  color: var(--ds-color-text-secondary);
+  margin: 0;
+  padding: 0;
+}
+
+.subtitle {
+  font-size: var(--ds-text-section-header-subtitle-font-size);
+  font-family: var(--ds-text-section-header-subtitle-font-family);
+  font-weight: var(--ds-text-section-header-subtitle-font-weight);
+  letter-spacing: var(--ds-text-section-header-subtitle-letter-spacing);
+  text-transform: var(--ds-text-section-header-subtitle-text-transform);
+  line-height: var(--ds-text-section-header-subtitle-line-height);
   color: var(--ds-color-text-secondary);
   margin: 0;
   padding: 0;

--- a/packages/ds/src/components/SectionHeader/SectionHeader.stories.tsx
+++ b/packages/ds/src/components/SectionHeader/SectionHeader.stories.tsx
@@ -8,9 +8,19 @@ const meta = {
   tags: ['autodocs'],
   argTypes: {
     children: { control: 'text' },
+    subtitle: { control: 'text' },
+    headingLevel: { control: 'select', options: [2, 3, 4, 5, 6] },
   },
   args: {
     children: 'Project Artifacts',
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Uppercase-mono section heading with an optional subtitle line. The `headingLevel` prop (default `3`) lets consumers pick the semantic heading element; `h1` is intentionally excluded since it is reserved for page titles. Consumers are responsible for maintaining a correct document outline — if a parent section already has an `h2` sibling, pick a deeper level here to avoid flat/broken heading hierarchies.',
+      },
+    },
   },
 } satisfies Meta<typeof SectionHeader>;
 
@@ -18,6 +28,14 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const WithSubtitle: Story = {
+  args: {
+    children: 'My tasks',
+    subtitle: '12 open · 3 in progress',
+    headingLevel: 2,
+  },
+};
 
 export const AllVariants: Story = {
   render: () => (

--- a/packages/ds/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/ds/src/components/SectionHeader/SectionHeader.test.tsx
@@ -8,24 +8,103 @@ describe('SectionHeader', () => {
     expect(screen.getByText('Project Artifacts')).toBeInTheDocument();
   });
 
-  it('renders as an h3 element', () => {
+  it('renders the heading as an h3 by default', () => {
     render(<SectionHeader>Label</SectionHeader>);
-    expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { level: 3, name: 'Label' }),
+    ).toBeInTheDocument();
   });
 
-  it('forwards ref to the heading element', () => {
-    const ref = { current: null } as React.RefObject<HTMLHeadingElement | null>;
+  it('renders the heading at the specified headingLevel', () => {
+    render(<SectionHeader headingLevel={2}>Label</SectionHeader>);
+    expect(
+      screen.getByRole('heading', { level: 2, name: 'Label' }),
+    ).toBeInTheDocument();
+  });
+
+  it('forwards ref to the container div element', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
     render(<SectionHeader ref={ref}>Label</SectionHeader>);
-    expect(ref.current).toBeInstanceOf(HTMLHeadingElement);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 
-  it('merges custom className', () => {
-    render(<SectionHeader className="custom">Label</SectionHeader>);
-    expect(screen.getByText('Label')).toHaveClass('custom');
+  it('merges custom className onto the container', () => {
+    const { container } = render(
+      <SectionHeader className="custom">Label</SectionHeader>,
+    );
+    expect(container.firstChild).toHaveClass('custom');
   });
 
   it('spreads additional HTML attributes', () => {
     render(<SectionHeader data-testid="section">Label</SectionHeader>);
     expect(screen.getByTestId('section')).toBeInTheDocument();
+  });
+
+  it('does not render the subtitle when it is not provided', () => {
+    render(<SectionHeader>Label</SectionHeader>);
+    expect(
+      screen.getByRole('heading', { name: 'Label' }).nextElementSibling,
+    ).toBeNull();
+  });
+
+  it('does not render the subtitle when it is an empty string', () => {
+    render(<SectionHeader subtitle="">Label</SectionHeader>);
+    expect(
+      screen.getByRole('heading', { name: 'Label' }).nextElementSibling,
+    ).toBeNull();
+  });
+
+  it('renders the subtitle when it is the number 0', () => {
+    render(<SectionHeader subtitle={0}>Label</SectionHeader>);
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+
+  it('does not render the subtitle when it is false', () => {
+    render(<SectionHeader subtitle={false}>Label</SectionHeader>);
+    expect(
+      screen.getByRole('heading', { name: 'Label' }).nextElementSibling,
+    ).toBeNull();
+  });
+
+  it('does not render the subtitle when it is null', () => {
+    render(<SectionHeader subtitle={null}>Label</SectionHeader>);
+    expect(
+      screen.getByRole('heading', { name: 'Label' }).nextElementSibling,
+    ).toBeNull();
+  });
+
+  it('renders the subtitle when provided', () => {
+    render(
+      <SectionHeader subtitle="12 open · 3 in progress">
+        My tasks
+      </SectionHeader>,
+    );
+    expect(screen.getByText('12 open · 3 in progress')).toBeInTheDocument();
+  });
+
+  it('accepts ReactNode for subtitle', () => {
+    render(
+      <SectionHeader
+        subtitle={
+          <>
+            <strong>12 open</strong> · 3 in progress
+          </>
+        }
+      >
+        My tasks
+      </SectionHeader>,
+    );
+    expect(screen.getByText('12 open')).toBeInTheDocument();
+    expect(screen.getByText(/3 in progress/)).toBeInTheDocument();
+  });
+
+  it('renders the heading above the subtitle in document order', () => {
+    render(<SectionHeader subtitle="meta">Title</SectionHeader>);
+    const heading = screen.getByRole('heading', { level: 3, name: 'Title' });
+    const subtitle = screen.getByText('meta');
+    expect(
+      heading.compareDocumentPosition(subtitle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/packages/ds/src/components/SectionHeader/SectionHeader.tsx
+++ b/packages/ds/src/components/SectionHeader/SectionHeader.tsx
@@ -1,17 +1,25 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
 import { cn } from '../../utils/cn';
 import styles from './SectionHeader.module.css';
 
-export type SectionHeaderProps = HTMLAttributes<HTMLHeadingElement>;
+// h1 is reserved for page titles; SectionHeader renders subsection headings
+type HeadingLevel = 2 | 3 | 4 | 5 | 6;
 
-export const SectionHeader = forwardRef<HTMLHeadingElement, SectionHeaderProps>(
-  ({ className, children, ...rest }, ref) => {
-    const classes = cn(styles.sectionHeader, className);
+export interface SectionHeaderProps extends HTMLAttributes<HTMLDivElement> {
+  subtitle?: ReactNode;
+  headingLevel?: HeadingLevel;
+}
 
+export const SectionHeader = forwardRef<HTMLDivElement, SectionHeaderProps>(
+  ({ className, children, subtitle, headingLevel = 3, ...rest }, ref) => {
+    const Heading = `h${headingLevel}` as const;
+    const hasSubtitle =
+      subtitle != null && subtitle !== false && subtitle !== '';
     return (
-      <h3 ref={ref} className={classes} {...rest}>
-        {children}
-      </h3>
+      <div ref={ref} className={cn(styles.sectionHeader, className)} {...rest}>
+        <Heading className={styles.title}>{children}</Heading>
+        {hasSubtitle && <div className={styles.subtitle}>{subtitle}</div>}
+      </div>
     );
   },
 );

--- a/packages/ds/src/tokens/typography.ts
+++ b/packages/ds/src/tokens/typography.ts
@@ -48,6 +48,15 @@ const buttonInputBase = {
   lineHeight: DEFAULT_LINE_HEIGHT,
 };
 
+const bodyRegularSans13 = {
+  fontSize: '13px',
+  fontFamily: fontFamilies.sans,
+  fontWeight: fontWeights.regular,
+  letterSpacing: 'normal',
+  textTransform: 'none',
+  lineHeight: DEFAULT_LINE_HEIGHT,
+};
+
 export const typographyScale = {
   sectionHeader: {
     fontSize: '10px',
@@ -57,6 +66,7 @@ export const typographyScale = {
     textTransform: 'uppercase',
     lineHeight: DEFAULT_LINE_HEIGHT,
   },
+  sectionHeaderSubtitle: bodyRegularSans13,
   microLabel: {
     fontSize: '9px',
     fontFamily: fontFamilies.mono,
@@ -171,14 +181,7 @@ export const typographyScale = {
     ...buttonInputBase,
     fontWeight: fontWeights.medium,
   },
-  searchInput: {
-    fontSize: '13px',
-    fontFamily: fontFamilies.sans,
-    fontWeight: fontWeights.regular,
-    letterSpacing: 'normal',
-    textTransform: 'none',
-    lineHeight: DEFAULT_LINE_HEIGHT,
-  },
+  searchInput: bodyRegularSans13,
   searchInputClear: {
     fontSize: '10px',
     fontFamily: fontFamilies.mono,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `SectionHeader`’s rendered DOM (from a single `h3` to a `div` wrapping a configurable heading) and ref/attribute typing, which may affect styling, accessibility, or consumer code relying on the previous heading element.
> 
> **Overview**
> `SectionHeader` now supports an optional `subtitle` line and a configurable semantic `headingLevel` (`h2`–`h6`, default `h3`), rendering the title and subtitle as a stacked flex column.
> 
> This refactors the component API to forward refs/HTML attributes to a new container `div` (with the heading inside), adds subtitle-specific styling, updates Storybook docs/examples, and expands tests to cover heading levels and subtitle rendering edge cases.
> 
> Typography tokens add `sectionHeaderSubtitle` (and reuse a new `bodyRegularSans13` token for `searchInput`) to support the subtitle text style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb8d51e5c80fa43dcf17cd932d2c834e2b58fce1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->