### PR TITLE
feat(ci): add PR preview deploys via gh-pages branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ['*']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -31,9 +34,9 @@ jobs:
     needs: validate
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -55,9 +58,9 @@ jobs:
     needs: validate
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -76,7 +79,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: packages/ds/playwright-report/

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -5,31 +5,29 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: pages-deploy
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .nvmrc
           cache: npm
       - run: npm ci
       - run: npm run build-storybook --workspace=packages/ds
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v4
+        env:
+          STORYBOOK_BASE_PATH: /${{ github.event.repository.name }}/
+      - uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
-          path: packages/ds/storybook-static
-      - id: deployment
-        uses: actions/deploy-pages@v5
+          folder: packages/ds/storybook-static
+          branch: gh-pages
+          clean: true
+          clean-exclude: |
+            pr-preview/

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,41 @@
+name: PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+jobs:
+  preview:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - if: github.event.action != 'closed'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - if: github.event.action != 'closed'
+        run: npm ci
+
+      - if: github.event.action != 'closed'
+        run: npm run build-storybook --workspace=packages/ds
+        env:
+          STORYBOOK_BASE_PATH: /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}/
+
+      - uses: rossjrw/pr-preview-action@ffa7509e91a3ec8dfc2e5536c4d5c1acdf7a6de9 # v1.8.1
+        with:
+          source-dir: packages/ds/storybook-static
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto

--- a/packages/ds/.storybook/main.ts
+++ b/packages/ds/.storybook/main.ts
@@ -9,6 +9,7 @@ const config: StorybookConfig = {
     options: {},
   },
   viteFinal(config) {
+    config.base = process.env.STORYBOOK_BASE_PATH || '/';
     config.plugins = config.plugins || [];
     config.plugins.push(dsTokensPlugin());
     return config;


### PR DESCRIPTION
  ## Summary      

- Adds Storybook preview deploys for every PR on GitHub Pages, scoped to `pr-preview/pr-<N>/` subpaths on the `gh-pages` branch.
- Migrates main's deploy from the artifact-based Pages flow to the same branch so previews                                                            and main can coexist. 
- Pins all workflow actions to SHAs and adds Dependabot for safe bumps.                                            
                                                                        
  ## Post merge checklist (order matters)                               
                                                                     
  1. **Wait** for `Deploy Storybook` on `main` to finish green (this is
     what populates the `gh-pages` root with main's Storybook, we neeed it).
  2. **Flip Pages source**: Settings → Pages → Source → "Deploy from a  
     branch" → `gh-pages` / `(root)`. Until this step, all preview URLs 
     (including this PRs) will 404 even though the deploys succeeded.  
  3. **Verify main**: open `https://alepaez-dev.github.io/TasksGO-UI/` and confirm Storybook renders abd we are good to go.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new GitHub Actions workflows that publish build artifacts to `gh-pages` with `contents: write` permissions, which can affect repo state if misconfigured. Also changes Storybook’s base path handling, which could break published/preview URLs if the env var is wrong.
> 
> **Overview**
> **Adds automated Storybook publishing via GitHub Actions.** Main-branch Storybook deploys now push `packages/ds/storybook-static` to the `gh-pages` branch (with cleaning that preserves `pr-preview/`) and set `STORYBOOK_BASE_PATH` so assets resolve under `/<repo>/`.
> 
> **Introduces per-PR Storybook previews.** A new `PR Preview` workflow builds Storybook for pull requests and publishes/removes previews under `pr-preview/pr-<number>/` on `gh-pages`, gated to same-repo PRs and sharing a `pages-deploy` concurrency group.
> 
> **Hardens and automates CI dependencies.** CI now pins GitHub Actions to specific SHAs, adds minimal `contents: read` permissions, and adds a `dependabot.yml` config to keep GitHub Actions dependencies updated weekly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c927ded77b33055f2c7e9d3a339f88f640690da9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->