### PR TITLE
feat(property-row): allow icon to be omitted

### DIFF
--- a/packages/ds/src/components/PropertyRow/PropertyRow.stories.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.stories.tsx
@@ -69,3 +69,10 @@ export const Placeholder: Story = {
     children: 'Search ticket...',
   },
 };
+
+export const WithoutIcon: Story = {
+  args: {
+    label: 'Sprint',
+    children: 'Q1-W4-INFRA',
+  },
+};

--- a/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
@@ -13,6 +13,15 @@ describe('PropertyRow', () => {
     expect(screen.getByText('Alex D.')).toBeInTheDocument();
   });
 
+  it('renders without an icon when icon prop is omitted', () => {
+    const { container } = render(
+      <PropertyRow label="Assignee">Alex D.</PropertyRow>,
+    );
+    expect(screen.getByText('Assignee')).toBeInTheDocument();
+    expect(screen.getByText('Alex D.')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
   it('renders a div when not interactive', () => {
     render(
       <PropertyRow icon="tag" label="Project">

--- a/packages/ds/src/components/PropertyRow/PropertyRow.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.tsx
@@ -5,7 +5,7 @@ import type { IconName } from '../../icons';
 import styles from './PropertyRow.module.css';
 
 export interface PropertyRowProps extends HTMLAttributes<HTMLDivElement> {
-  icon: IconName;
+  icon?: IconName;
   label: string;
   onClick?: () => void;
 }
@@ -18,7 +18,7 @@ export const PropertyRow = forwardRef<HTMLDivElement, PropertyRowProps>(
     return (
       <div ref={ref} className={cn(styles.row, className)} {...rest}>
         <div className={styles.left}>
-          <Icon name={icon} size="sm" className={styles.icon} />
+          {icon && <Icon name={icon} size="sm" className={styles.icon} />}
           <span className={styles.label}>{label}</span>
         </div>
         <Value


### PR DESCRIPTION
<img width="2167" height="1418" alt="refactor-property-row" src="https://github.com/user-attachments/assets/bf328253-59ab-4d8b-bb4b-5e3c05d9d318" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/component API tweak: `icon` becomes optional and rendering is guarded; main risk is minor layout/spacing regressions where consumers relied on the icon slot.
> 
> **Overview**
> `PropertyRow` now supports omitting the `icon` prop by making it optional and conditionally rendering the `Icon` only when provided.
> 
> Adds a Storybook example (`WithoutIcon`) and a unit test asserting no `svg` is rendered when `icon` is not passed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e212c889b2f3a549822071b2fb2b02b68884df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->