### PR TITLE
feat(tabs): add controlled tablist

### DIFF
--- a/packages/ds/src/components/Tabs/Tabs.module.css
+++ b/packages/ds/src/components/Tabs/Tabs.module.css
@@ -1,0 +1,44 @@
+.tablist {
+  display: flex;
+  gap: var(--ds-space-scale-lg);
+}
+
+.tab {
+  position: relative;
+  padding: var(--ds-space-scale-sm) 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--ds-color-text-secondary);
+  font-size: var(--ds-text-nav-label-font-size);
+  font-family: var(--ds-text-nav-label-font-family);
+  font-weight: var(--ds-text-nav-label-font-weight);
+  letter-spacing: var(--ds-text-nav-label-letter-spacing);
+  line-height: var(--ds-text-nav-label-line-height);
+  /* -1px lets the active underline overlap a 1px parent border (see WithParentBorder story). */
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition-property: var(--ds-transition-property);
+  transition-duration: var(--ds-transition-duration);
+  transition-timing-function: var(--ds-transition-timing-function);
+}
+
+.tab:hover:not(.disabled):not(.selected) {
+  color: var(--ds-color-text-primary);
+}
+
+.tab:focus-visible {
+  outline: var(--ds-focus-ring-width) solid transparent;
+  box-shadow: var(--ds-focus-ring);
+  border-radius: var(--ds-radius-sm);
+}
+
+.selected {
+  color: var(--ds-color-text-primary);
+  border-bottom-color: var(--ds-color-tabs-active-border);
+}
+
+.disabled {
+  color: var(--ds-color-text-disabled);
+  cursor: not-allowed;
+}

--- a/packages/ds/src/components/Tabs/Tabs.stories.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.stories.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Tabs, type TabItem } from './Tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Components/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: [
+          'Stateless, controlled tablist. Renders only the tab buttons — consumers render the panels based on `value`. Implements WAI-ARIA tablist keyboard pattern (Arrow keys move focus & activate, Home/End jump to first/last, disabled tabs are skipped).',
+          '',
+          "**The component does not draw a bottom border under the tablist.** The active tab's underline visually merges with whatever bottom border the consumer adds to the wrapping element (a 1px negative margin handles the overlap). See the `WithParentBorder` story.",
+        ].join('\n'),
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '480px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Tabs>;
+
+const ticketTabs: readonly TabItem[] = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'dev', label: 'Dev' },
+  { value: 'qa', label: 'QA' },
+  { value: 'activity', label: 'Activity' },
+];
+
+function ControlledTabs({
+  items,
+  initial,
+  ariaLabel,
+}: {
+  items: readonly TabItem[];
+  initial: string;
+  ariaLabel: string;
+}) {
+  const [active, setActive] = useState(initial);
+  return (
+    <Tabs
+      items={items}
+      value={active}
+      onValueChange={setActive}
+      aria-label={ariaLabel}
+    />
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <ControlledTabs
+      items={ticketTabs}
+      initial="overview"
+      ariaLabel="Ticket sections"
+    />
+  ),
+};
+
+export const WithParentBorder: Story = {
+  render: () => (
+    <div
+      style={{
+        borderBottom: '1px solid var(--ds-color-border-default)',
+      }}
+    >
+      <ControlledTabs
+        items={ticketTabs}
+        initial="overview"
+        ariaLabel="Ticket sections"
+      />
+    </div>
+  ),
+};
+
+export const WithDisabledTab: Story = {
+  render: () => (
+    <ControlledTabs
+      items={[
+        { value: 'overview', label: 'Overview' },
+        { value: 'dev', label: 'Dev' },
+        { value: 'qa', label: 'QA', disabled: true },
+        { value: 'activity', label: 'Activity' },
+      ]}
+      initial="overview"
+      ariaLabel="Ticket sections"
+    />
+  ),
+};
+
+export const TwoTabs: Story = {
+  render: () => (
+    <ControlledTabs
+      items={[
+        { value: 'active', label: 'Active' },
+        { value: 'archived', label: 'Archived' },
+      ]}
+      initial="active"
+      ariaLabel="Task lists"
+    />
+  ),
+};
+
+export const LongLabels: Story = {
+  render: () => (
+    <ControlledTabs
+      items={[
+        { value: 'overview', label: 'Project overview' },
+        { value: 'env', label: 'Environments and infrastructure' },
+        { value: 'audit', label: 'Audit log' },
+      ]}
+      initial="overview"
+      ariaLabel="Project sections"
+    />
+  ),
+};

--- a/packages/ds/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.test.tsx
@@ -174,6 +174,29 @@ describe('Tabs', () => {
     );
   });
 
+  it('falls back to first enabled tab when value matches a disabled tab', () => {
+    const selectedDisabled: readonly TabItem[] = [
+      { value: 'overview', label: 'Overview', disabled: true },
+      { value: 'dev', label: 'Dev' },
+      { value: 'qa', label: 'QA' },
+    ];
+    render(
+      <Tabs
+        items={selectedDisabled}
+        value="overview"
+        onValueChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    );
+    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+  });
+
   it('makes no tab focusable when all tabs are disabled and no value matches', () => {
     const allDisabled: readonly TabItem[] = [
       { value: 'a', label: 'A', disabled: true },

--- a/packages/ds/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,213 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { Tabs, type TabItem } from './Tabs';
+
+const items: readonly TabItem[] = [
+  { value: 'overview', label: 'Overview' },
+  { value: 'dev', label: 'Dev' },
+  { value: 'qa', label: 'QA' },
+  { value: 'activity', label: 'Activity' },
+];
+
+describe('Tabs', () => {
+  it('renders a tablist with one tab per item', () => {
+    render(
+      <Tabs
+        items={items}
+        value="overview"
+        onValueChange={() => {}}
+        aria-label="Sections"
+      />,
+    );
+    const tablist = screen.getByRole('tablist', { name: 'Sections' });
+    expect(tablist).toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(items.length);
+  });
+
+  it('marks the active tab with aria-selected="true" and tabIndex=0', () => {
+    render(<Tabs items={items} value="dev" onValueChange={() => {}} />);
+    const active = screen.getByRole('tab', { name: 'Dev' });
+    expect(active).toHaveAttribute('aria-selected', 'true');
+    expect(active).toHaveAttribute('tabindex', '0');
+  });
+
+  it('marks inactive tabs with aria-selected="false" and tabIndex=-1', () => {
+    render(<Tabs items={items} value="dev" onValueChange={() => {}} />);
+    const inactive = screen.getByRole('tab', { name: 'Overview' });
+    expect(inactive).toHaveAttribute('aria-selected', 'false');
+    expect(inactive).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('fires onChange with the clicked value', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="overview" onValueChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Dev' }));
+    expect(onChange).toHaveBeenCalledWith('dev');
+  });
+
+  it('does not fire onChange when clicking the already-active tab', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="overview" onValueChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'Overview' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('disables a tab via the native disabled attribute', () => {
+    const disabled = [...items];
+    disabled[2] = { ...disabled[2], disabled: true };
+    render(<Tabs items={disabled} value="overview" onValueChange={() => {}} />);
+    const qa = screen.getByRole('tab', { name: 'QA' });
+    expect(qa).toBeDisabled();
+    expect(qa).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('does not fire onChange when clicking a disabled tab', () => {
+    const onChange = vi.fn();
+    const disabled = [...items];
+    disabled[2] = { ...disabled[2], disabled: true };
+    render(<Tabs items={disabled} value="overview" onValueChange={onChange} />);
+    fireEvent.click(screen.getByRole('tab', { name: 'QA' }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ArrowRight activates the next tab', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="overview" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Overview' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).toHaveBeenCalledWith('dev');
+  });
+
+  it('ArrowLeft activates the previous tab', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="dev" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Dev' }), {
+      key: 'ArrowLeft',
+    });
+    expect(onChange).toHaveBeenCalledWith('overview');
+  });
+
+  it('ArrowRight wraps from last to first', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="activity" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Activity' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).toHaveBeenCalledWith('overview');
+  });
+
+  it('ArrowLeft wraps from first to last', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="overview" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Overview' }), {
+      key: 'ArrowLeft',
+    });
+    expect(onChange).toHaveBeenCalledWith('activity');
+  });
+
+  it('Home activates the first enabled tab', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="activity" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Activity' }), {
+      key: 'Home',
+    });
+    expect(onChange).toHaveBeenCalledWith('overview');
+  });
+
+  it('End activates the last enabled tab', () => {
+    const onChange = vi.fn();
+    render(<Tabs items={items} value="overview" onValueChange={onChange} />);
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Overview' }), {
+      key: 'End',
+    });
+    expect(onChange).toHaveBeenCalledWith('activity');
+  });
+
+  it('arrow keys skip disabled tabs', () => {
+    const onChange = vi.fn();
+    const withDisabled: readonly TabItem[] = [
+      { value: 'overview', label: 'Overview' },
+      { value: 'dev', label: 'Dev', disabled: true },
+      { value: 'qa', label: 'QA' },
+    ];
+    render(
+      <Tabs items={withDisabled} value="overview" onValueChange={onChange} />,
+    );
+    fireEvent.keyDown(screen.getByRole('tab', { name: 'Overview' }), {
+      key: 'ArrowRight',
+    });
+    expect(onChange).toHaveBeenCalledWith('qa');
+  });
+
+  it('falls back to the first enabled tab being focusable when value matches no item', () => {
+    render(<Tabs items={items} value="nonexistent" onValueChange={() => {}} />);
+    const overview = screen.getByRole('tab', { name: 'Overview' });
+    expect(overview).toHaveAttribute('tabindex', '0');
+    expect(overview).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    );
+  });
+
+  it('skips disabled tabs when picking the fallback focusable tab', () => {
+    const withFirstDisabled: readonly TabItem[] = [
+      { value: 'overview', label: 'Overview', disabled: true },
+      { value: 'dev', label: 'Dev' },
+      { value: 'qa', label: 'QA' },
+    ];
+    render(
+      <Tabs
+        items={withFirstDisabled}
+        value="nonexistent"
+        onValueChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+      'tabindex',
+      '-1',
+    );
+    expect(screen.getByRole('tab', { name: 'Dev' })).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+  });
+
+  it('makes no tab focusable when all tabs are disabled and no value matches', () => {
+    const allDisabled: readonly TabItem[] = [
+      { value: 'a', label: 'A', disabled: true },
+      { value: 'b', label: 'B', disabled: true },
+    ];
+    render(<Tabs items={allDisabled} value="" onValueChange={() => {}} />);
+    screen.getAllByRole('tab').forEach((tab) => {
+      expect(tab).toHaveAttribute('tabindex', '-1');
+    });
+  });
+
+  it('forwards ref to the tablist element', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(
+      <Tabs
+        ref={ref}
+        items={items}
+        value="overview"
+        onValueChange={() => {}}
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current?.getAttribute('role')).toBe('tablist');
+  });
+
+  it('merges custom className onto the tablist', () => {
+    render(
+      <Tabs
+        items={items}
+        value="overview"
+        onValueChange={() => {}}
+        className="custom"
+      />,
+    );
+    expect(screen.getByRole('tablist')).toHaveClass('custom');
+  });
+});

--- a/packages/ds/src/components/Tabs/Tabs.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.tsx
@@ -1,0 +1,151 @@
+import {
+  forwardRef,
+  useRef,
+  type HTMLAttributes,
+  type KeyboardEvent,
+} from 'react';
+import { cn } from '../../utils/cn';
+import styles from './Tabs.module.css';
+
+export interface TabItem {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface TabsProps extends HTMLAttributes<HTMLDivElement> {
+  items: readonly TabItem[];
+  value: string;
+  onValueChange: (value: string) => void;
+  idPrefix?: string;
+  'aria-label'?: string;
+}
+
+export function getTabId(idPrefix: string, value: string): string {
+  return `${idPrefix}-tab-${value}`;
+}
+
+export function getTabPanelId(idPrefix: string, value: string): string {
+  return `${idPrefix}-panel-${value}`;
+}
+
+export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
+  (
+    {
+      items,
+      value,
+      onValueChange,
+      idPrefix,
+      'aria-label': ariaLabel,
+      className,
+      ...rest
+    },
+    ref,
+  ) => {
+    const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+    const findNextEnabled = (start: number, step: 1 | -1): number => {
+      const n = items.length;
+      for (let i = 1; i <= n; i++) {
+        const idx = (start + step * i + n) % n;
+        if (!items[idx].disabled) return idx;
+      }
+      return start;
+    };
+
+    const findFirstEnabled = (): number => {
+      const i = items.findIndex((it) => !it.disabled);
+      return i === -1 ? -1 : i;
+    };
+
+    const findLastEnabled = (): number => {
+      for (let i = items.length - 1; i >= 0; i--) {
+        if (!items[i].disabled) return i;
+      }
+      return -1;
+    };
+
+    const activateIndex = (idx: number) => {
+      if (idx < 0) return;
+      const target = items[idx];
+      buttonRefs.current[idx]?.focus();
+      if (target.value !== value) {
+        onValueChange(target.value);
+      }
+    };
+
+    const handleKeyDown = (
+      event: KeyboardEvent<HTMLButtonElement>,
+      currentIndex: number,
+    ) => {
+      switch (event.key) {
+        case 'ArrowRight':
+          event.preventDefault();
+          activateIndex(findNextEnabled(currentIndex, 1));
+          break;
+        case 'ArrowLeft':
+          event.preventDefault();
+          activateIndex(findNextEnabled(currentIndex, -1));
+          break;
+        case 'Home':
+          event.preventDefault();
+          activateIndex(findFirstEnabled());
+          break;
+        case 'End':
+          event.preventDefault();
+          activateIndex(findLastEnabled());
+          break;
+      }
+    };
+
+    const selectedIndex = items.findIndex((it) => it.value === value);
+    const focusableIndex =
+      selectedIndex !== -1 ? selectedIndex : findFirstEnabled();
+
+    return (
+      <div
+        ref={ref}
+        role="tablist"
+        aria-label={ariaLabel}
+        aria-orientation="horizontal"
+        className={cn(styles.tablist, className)}
+        {...rest}
+      >
+        {items.map((item, index) => {
+          const selected = index === selectedIndex;
+          return (
+            <button
+              key={item.value}
+              ref={(el) => {
+                buttonRefs.current[index] = el;
+              }}
+              type="button"
+              role="tab"
+              id={idPrefix ? getTabId(idPrefix, item.value) : undefined}
+              aria-controls={
+                idPrefix ? getTabPanelId(idPrefix, item.value) : undefined
+              }
+              aria-selected={selected}
+              disabled={item.disabled}
+              tabIndex={index === focusableIndex ? 0 : -1}
+              className={cn(
+                styles.tab,
+                selected && styles.selected,
+                item.disabled && styles.disabled,
+              )}
+              onClick={() => {
+                if (item.disabled) return;
+                if (item.value !== value) onValueChange(item.value);
+              }}
+              onKeyDown={(event) => handleKeyDown(event, index)}
+            >
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+    );
+  },
+);
+
+Tabs.displayName = 'Tabs';

--- a/packages/ds/src/components/Tabs/Tabs.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.tsx
@@ -98,11 +98,10 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
       }
     };
 
-    const selectedIndex = items.findIndex((it) => it.value === value);
-    const focusableIndex =
-      selectedIndex !== -1 && !items[selectedIndex].disabled
-        ? selectedIndex
-        : findFirstEnabled();
+    const matchedIndex = items.findIndex((it) => it.value === value);
+    const isMatchActive = matchedIndex !== -1 && !items[matchedIndex].disabled;
+    const selectedIndex = isMatchActive ? matchedIndex : -1;
+    const focusableIndex = isMatchActive ? matchedIndex : findFirstEnabled();
 
     return (
       <div

--- a/packages/ds/src/components/Tabs/Tabs.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.tsx
@@ -100,7 +100,9 @@ export const Tabs = forwardRef<HTMLDivElement, TabsProps>(
 
     const selectedIndex = items.findIndex((it) => it.value === value);
     const focusableIndex =
-      selectedIndex !== -1 ? selectedIndex : findFirstEnabled();
+      selectedIndex !== -1 && !items[selectedIndex].disabled
+        ? selectedIndex
+        : findFirstEnabled();
 
     return (
       <div

--- a/packages/ds/src/components/Tabs/index.ts
+++ b/packages/ds/src/components/Tabs/index.ts
@@ -1,0 +1,7 @@
+export {
+  Tabs,
+  getTabId,
+  getTabPanelId,
+  type TabsProps,
+  type TabItem,
+} from './Tabs';

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -105,6 +105,13 @@ export {
 } from './components/TaskDrawer';
 export { PropertyRow, type PropertyRowProps } from './components/PropertyRow';
 export {
+  Tabs,
+  getTabId,
+  getTabPanelId,
+  type TabsProps,
+  type TabItem,
+} from './components/Tabs';
+export {
   RecentTaskList,
   type RecentTaskListProps,
   type RecentTaskItem,

--- a/packages/ds/src/tokens/colors.ts
+++ b/packages/ds/src/tokens/colors.ts
@@ -182,6 +182,10 @@ export const colors = {
   taskDrawer: {
     footerBg: 'rgba(248, 249, 250, 0.3)',
   },
+
+  tabs: {
+    activeBorder: status.info,
+  },
 } as const;
 
 export type ColorGroup = keyof typeof colors;


### PR DESCRIPTION

https://github.com/user-attachments/assets/26f915a1-e053-412b-9603-3a4431bb3f16


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new design-system component and token without changing existing component behavior; main risk is minor UI/ARIA regressions in the new `Tabs` keyboard/focus handling.
> 
> **Overview**
> Adds a new controlled `Tabs` component that renders an ARIA-compliant `tablist` with clickable/keyboard-navigable tabs, disabled handling, and optional `idPrefix` helpers (`getTabId`/`getTabPanelId`) for wiring tabs to external panels.
> 
> Includes new styles, Storybook coverage, and a comprehensive test suite for focus/selection/keyboard behavior, and exports `Tabs` from the package root alongside a new `colors.tabs.activeBorder` token used for the active underline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86e67e12015849da78e2475a737623612910d888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->