### PR TITLE
feat(card): add Card component with header slot and subtle variant

### DIFF
--- a/packages/ds/src/components/Card/Card.module.css
+++ b/packages/ds/src/components/Card/Card.module.css
@@ -1,0 +1,37 @@
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-scale-sm);
+  padding: var(--ds-space-scale-md);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-xl);
+  background-color: var(--ds-color-surface-primary);
+  font-size: var(--ds-text-card-body-font-size);
+  font-family: var(--ds-text-card-body-font-family);
+  font-weight: var(--ds-text-card-body-font-weight);
+  line-height: var(--ds-text-card-body-line-height);
+  color: var(--ds-color-text-primary);
+}
+
+.subtle {
+  background-color: var(--ds-color-surface-secondary);
+}
+
+.header {
+  font-size: var(--ds-text-card-header-font-size);
+  font-family: var(--ds-text-card-header-font-family);
+  font-weight: var(--ds-text-card-header-font-weight);
+  letter-spacing: var(--ds-text-card-header-letter-spacing);
+  text-transform: var(--ds-text-card-header-text-transform);
+  line-height: var(--ds-text-card-header-line-height);
+  color: var(--ds-color-text-primary);
+}
+
+.card > :where(p, ul, ol) {
+  margin: 0;
+}
+
+.card > :where(ul, ol) {
+  padding-left: var(--ds-space-scale-md);
+  color: var(--ds-color-text-secondary);
+}

--- a/packages/ds/src/components/Card/Card.module.css
+++ b/packages/ds/src/components/Card/Card.module.css
@@ -5,12 +5,15 @@
   padding: var(--ds-space-scale-md);
   border: 1px solid var(--ds-color-border-default);
   border-radius: var(--ds-radius-xl);
-  background-color: var(--ds-color-surface-primary);
   font-size: var(--ds-text-card-body-font-size);
   font-family: var(--ds-text-card-body-font-family);
   font-weight: var(--ds-text-card-body-font-weight);
   line-height: var(--ds-text-card-body-line-height);
   color: var(--ds-color-text-primary);
+}
+
+.default {
+  background-color: var(--ds-color-surface-primary);
 }
 
 .subtle {

--- a/packages/ds/src/components/Card/Card.stories.tsx
+++ b/packages/ds/src/components/Card/Card.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/Card',
+  component: Card,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A boxed surface for grouping related content. Optional `header` slot renders a small caps label above the body. `variant="subtle"` switches the background from the default surface (white) to the secondary surface (light gray).',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'subtle'],
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '320px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  render: () => (
+    <Card>
+      <p>A basic card with only body content and no header.</p>
+    </Card>
+  ),
+};
+
+export const WithHeader: Story = {
+  render: () => (
+    <Card header="Included">
+      <ul>
+        <li>GET /v1/assets/*</li>
+        <li>GET /v1/metadata/*</li>
+        <li>Cache invalidation via SNS</li>
+      </ul>
+    </Card>
+  ),
+};
+
+export const Subtle: Story = {
+  render: () => (
+    <Card variant="subtle" header="Included">
+      <ul>
+        <li>GET /v1/assets/*</li>
+        <li>GET /v1/metadata/*</li>
+        <li>Cache invalidation via SNS</li>
+      </ul>
+    </Card>
+  ),
+};
+
+export const TwoColumn: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ width: '640px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr',
+        gap: 'var(--ds-space-scale-md)',
+      }}
+    >
+      <Card variant="subtle" header="Included">
+        <ul>
+          <li>GET /v1/assets/*</li>
+          <li>GET /v1/metadata/*</li>
+          <li>Cache invalidation via SNS</li>
+        </ul>
+      </Card>
+      <Card header="Excluded">
+        <ul>
+          <li>WebSocket streams</li>
+          <li>POST/PUT operations</li>
+        </ul>
+      </Card>
+    </div>
+  ),
+};

--- a/packages/ds/src/components/Card/Card.test.tsx
+++ b/packages/ds/src/components/Card/Card.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Card } from './Card';
+
+describe('Card', () => {
+  it('renders children', () => {
+    render(
+      <Card>
+        <p>Body content</p>
+      </Card>,
+    );
+    expect(screen.getByText('Body content')).toBeInTheDocument();
+  });
+
+  it('renders header content when provided', () => {
+    render(
+      <Card header="Included">
+        <p>Body</p>
+      </Card>,
+    );
+    expect(screen.getByText('Included')).toBeInTheDocument();
+  });
+
+  it('does not render the header text when header is omitted', () => {
+    render(
+      <Card>
+        <p>Body</p>
+      </Card>,
+    );
+    expect(screen.queryByText('Included')).not.toBeInTheDocument();
+  });
+
+  it('applies the default variant class by default', () => {
+    const { container } = render(
+      <Card>
+        <p>Body</p>
+      </Card>,
+    );
+    expect(container.firstChild).toHaveClass('default');
+  });
+
+  it('applies the subtle variant class when variant="subtle"', () => {
+    const { container } = render(
+      <Card variant="subtle">
+        <p>Body</p>
+      </Card>,
+    );
+    expect(container.firstChild).toHaveClass('subtle');
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(
+      <Card ref={ref}>
+        <p>Body</p>
+      </Card>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges custom className onto the root element', () => {
+    const { container } = render(
+      <Card className="custom">
+        <p>Body</p>
+      </Card>,
+    );
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes onto the root element', () => {
+    render(
+      <Card data-testid="my-card">
+        <p>Body</p>
+      </Card>,
+    );
+    expect(screen.getByTestId('my-card')).toBeInTheDocument();
+  });
+});

--- a/packages/ds/src/components/Card/Card.tsx
+++ b/packages/ds/src/components/Card/Card.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { cn } from '../../utils/cn';
+import styles from './Card.module.css';
+
+type CardVariant = 'default' | 'subtle';
+
+export interface CardProps extends HTMLAttributes<HTMLDivElement> {
+  header?: ReactNode;
+  variant?: CardVariant;
+}
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ header, variant = 'default', children, className, ...rest }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(styles.card, styles[variant], className)}
+        {...rest}
+      >
+        {header !== undefined && <div className={styles.header}>{header}</div>}
+        {children}
+      </div>
+    );
+  },
+);
+
+Card.displayName = 'Card';

--- a/packages/ds/src/components/Card/Card.tsx
+++ b/packages/ds/src/components/Card/Card.tsx
@@ -17,7 +17,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(
         className={cn(styles.card, styles[variant], className)}
         {...rest}
       >
-        {header !== undefined && <div className={styles.header}>{header}</div>}
+        {header && <div className={styles.header}>{header}</div>}
         {children}
       </div>
     );

--- a/packages/ds/src/components/Card/index.ts
+++ b/packages/ds/src/components/Card/index.ts
@@ -1,0 +1,1 @@
+export { Card, type CardProps } from './Card';

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -104,6 +104,7 @@ export {
   type TaskDrawerSectionProps,
 } from './components/TaskDrawer';
 export { PropertyRow, type PropertyRowProps } from './components/PropertyRow';
+export { Card, type CardProps } from './components/Card';
 export {
   Tabs,
   getTabId,

--- a/packages/ds/src/tokens/typography.ts
+++ b/packages/ds/src/tokens/typography.ts
@@ -75,6 +75,15 @@ export const typographyScale = {
   },
   sectionHeaderSubtitle: bodyRegularSans13,
   optionLabel: bodyRegularSans14,
+  cardBody: bodyRegularSans14,
+  cardHeader: {
+    fontSize: '12px',
+    fontFamily: fontFamilies.sans,
+    fontWeight: fontWeights.bold,
+    letterSpacing: '0.05em',
+    textTransform: 'uppercase',
+    lineHeight: DEFAULT_LINE_HEIGHT,
+  },
   resultSubtitle: {
     fontSize: '10px',
     fontFamily: fontFamilies.mono,


### PR DESCRIPTION

https://github.com/user-attachments/assets/a6e276cd-5375-4094-af99-6b1126f8e452


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new design-system component plus new typography tokens and exports, with minimal impact on existing behavior aside from potential styling/token name collisions.
> 
> **Overview**
> Adds a new `Card` component to the design system, including a `header` slot, `default`/`subtle` visual variants, ref forwarding, and pass-through HTML attributes.
> 
> Introduces accompanying CSS module styling, Storybook stories for common layouts, and a Vitest test suite, and exports `Card` from the package entrypoint.
> 
> Extends typography tokens with `cardBody` and `cardHeader` scales to support the component’s text styles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27894b3ed493733411df4d2a773f2023a301a0ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->