### PR TITLE
feat(ticket-title-block): add TicketTitleBlock and high badge variant

### DIFF
--- a/packages/ds/src/components/Avatar/Avatar.tsx
+++ b/packages/ds/src/components/Avatar/Avatar.tsx
@@ -14,12 +14,7 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
 
 export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(
   ({ initial, variant = 'project', size = 'md', className, ...rest }, ref) => {
-    const classes = cn(
-      styles.avatar,
-      styles[variant],
-      size === 'sm' && styles.sm,
-      className,
-    );
+    const classes = cn(styles.avatar, styles[variant], styles[size], className);
 
     return (
       <span ref={ref} role="img" className={classes} {...rest}>

--- a/packages/ds/src/components/Badge/Badge.module.css
+++ b/packages/ds/src/components/Badge/Badge.module.css
@@ -36,3 +36,9 @@
   color: var(--ds-color-badge-done-text);
   border-color: var(--ds-color-badge-done-border);
 }
+
+.high {
+  background-color: var(--ds-color-badge-high-background);
+  color: var(--ds-color-badge-high-text);
+  border-color: var(--ds-color-badge-high-border);
+}

--- a/packages/ds/src/components/Badge/Badge.stories.tsx
+++ b/packages/ds/src/components/Badge/Badge.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'progress', 'todo', 'done'],
+      options: ['default', 'progress', 'todo', 'done', 'high'],
     },
     children: { control: 'text' },
   },
@@ -34,6 +34,10 @@ export const Done: Story = {
   args: { variant: 'done', children: 'Done' },
 };
 
+export const High: Story = {
+  args: { variant: 'high', children: 'High Prio' },
+};
+
 export const AllVariants: Story = {
   render: () => (
     <div
@@ -47,6 +51,7 @@ export const AllVariants: Story = {
       <Badge variant="progress">In Progress</Badge>
       <Badge variant="todo">To Do</Badge>
       <Badge variant="done">Done</Badge>
+      <Badge variant="high">High Prio</Badge>
     </div>
   ),
 };

--- a/packages/ds/src/components/Badge/Badge.tsx
+++ b/packages/ds/src/components/Badge/Badge.tsx
@@ -2,7 +2,7 @@ import { forwardRef, type HTMLAttributes } from 'react';
 import { cn } from '../../utils/cn';
 import styles from './Badge.module.css';
 
-type BadgeVariant = 'default' | 'progress' | 'todo' | 'done';
+type BadgeVariant = 'default' | 'progress' | 'todo' | 'done' | 'high';
 
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.module.css
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.module.css
@@ -1,0 +1,27 @@
+.block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-scale-md);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-scale-md);
+}
+
+.badges {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-scale-sm);
+}
+
+.title {
+  margin: 0;
+  font-size: var(--ds-text-page-title-font-size);
+  font-family: var(--ds-text-page-title-font-family);
+  font-weight: var(--ds-text-page-title-font-weight);
+  letter-spacing: var(--ds-text-page-title-letter-spacing);
+  line-height: var(--ds-text-page-title-line-height);
+  color: var(--ds-color-text-primary);
+}

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { TicketTitleBlock } from './TicketTitleBlock';
+import { Avatar } from '../Avatar';
+
+const meta: Meta<typeof TicketTitleBlock> = {
+  title: 'Components/TicketTitleBlock',
+  component: TicketTitleBlock,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Page-level title block for a ticket: an optional row of status badges and an avatar slot above a page heading. The top meta row is omitted entirely when both `badges` and `avatar` are absent.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '720px', padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof TicketTitleBlock>;
+
+const ticketTitle = 'Implement dynamic edge-caching for API gateway responses';
+
+export const Default: Story = {
+  args: {
+    title: ticketTitle,
+    badges: [
+      { label: 'In Progress', variant: 'progress' },
+      { label: 'High Prio', variant: 'high' },
+    ],
+    avatar: (
+      <Avatar initial="AP" aria-label="Ale P." variant="profile" size="sm" />
+    ),
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    title: ticketTitle,
+    badges: [
+      { label: 'In Progress', variant: 'progress' },
+      { label: 'High Prio', variant: 'high' },
+    ],
+  },
+};
+
+export const WithoutBadges: Story = {
+  args: {
+    title: ticketTitle,
+    avatar: (
+      <Avatar initial="AP" aria-label="Ale P." variant="profile" size="sm" />
+    ),
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    title: ticketTitle,
+  },
+};

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.test.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TicketTitleBlock } from './TicketTitleBlock';
+
+describe('TicketTitleBlock', () => {
+  it('renders the title as an h1', () => {
+    render(<TicketTitleBlock title="Edge caching" />);
+    const heading = screen.getByRole('heading', {
+      level: 1,
+      name: 'Edge caching',
+    });
+    expect(heading).toBeInTheDocument();
+  });
+
+  it('renders all badges with their labels', () => {
+    render(
+      <TicketTitleBlock
+        title="Edge caching"
+        badges={[
+          { label: 'In Progress', variant: 'progress' },
+          { label: 'High Prio', variant: 'high' },
+        ]}
+      />,
+    );
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+    expect(screen.getByText('High Prio')).toBeInTheDocument();
+  });
+
+  it('renders the avatar slot when provided', () => {
+    render(
+      <TicketTitleBlock
+        title="Edge caching"
+        avatar={<span data-testid="avatar">JD</span>}
+      />,
+    );
+    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  });
+
+  it('omits the meta row entirely when badges and avatar are both absent', () => {
+    const { container } = render(<TicketTitleBlock title="Edge caching" />);
+    expect(container.querySelectorAll('div').length).toBe(1);
+  });
+
+  it('renders the meta row when only badges are provided', () => {
+    render(
+      <TicketTitleBlock
+        title="Edge caching"
+        badges={[{ label: 'Done', variant: 'done' }]}
+      />,
+    );
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+
+  it('renders the meta row when only avatar is provided', () => {
+    render(
+      <TicketTitleBlock
+        title="Edge caching"
+        avatar={<span data-testid="avatar">JD</span>}
+      />,
+    );
+    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(<TicketTitleBlock ref={ref} title="Edge caching" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges custom className', () => {
+    const { container } = render(
+      <TicketTitleBlock title="Edge caching" className="custom" />,
+    );
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes', () => {
+    render(<TicketTitleBlock title="Edge caching" data-testid="block" />);
+    expect(screen.getByTestId('block')).toBeInTheDocument();
+  });
+});

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.tsx
@@ -1,0 +1,44 @@
+import { forwardRef, type HTMLAttributes, type ReactNode } from 'react';
+import { Badge, type BadgeProps } from '../Badge';
+import { cn } from '../../utils/cn';
+import styles from './TicketTitleBlock.module.css';
+
+export interface TicketTitleBlockBadge {
+  label: string;
+  variant?: BadgeProps['variant'];
+}
+
+export interface TicketTitleBlockProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  badges?: readonly TicketTitleBlockBadge[];
+  avatar?: ReactNode;
+}
+
+export const TicketTitleBlock = forwardRef<
+  HTMLDivElement,
+  TicketTitleBlockProps
+>(({ title, badges, avatar, className, ...rest }, ref) => {
+  const hasMeta = (badges && badges.length > 0) || avatar != null;
+
+  return (
+    <div ref={ref} className={cn(styles.block, className)} {...rest}>
+      {hasMeta && (
+        <div className={styles.meta}>
+          {badges && badges.length > 0 && (
+            <div className={styles.badges}>
+              {badges.map((badge, i) => (
+                <Badge key={i} variant={badge.variant}>
+                  {badge.label}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {avatar}
+        </div>
+      )}
+      <h1 className={styles.title}>{title}</h1>
+    </div>
+  );
+});
+
+TicketTitleBlock.displayName = 'TicketTitleBlock';

--- a/packages/ds/src/components/TicketTitleBlock/index.ts
+++ b/packages/ds/src/components/TicketTitleBlock/index.ts
@@ -1,0 +1,5 @@
+export {
+  TicketTitleBlock,
+  type TicketTitleBlockProps,
+  type TicketTitleBlockBadge,
+} from './TicketTitleBlock';

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -113,6 +113,11 @@ export {
   type TabItem,
 } from './components/Tabs';
 export {
+  TicketTitleBlock,
+  type TicketTitleBlockProps,
+  type TicketTitleBlockBadge,
+} from './components/TicketTitleBlock';
+export {
   RecentTaskList,
   type RecentTaskListProps,
   type RecentTaskItem,

--- a/packages/ds/src/tokens/colors.ts
+++ b/packages/ds/src/tokens/colors.ts
@@ -19,6 +19,7 @@ const border = {
 const surface = {
   primary: '#FFFFFF',
   secondary: '#F8F9FA',
+  muted: '#e5e7eb',
   hover: '#eff1f3',
 } as const;
 
@@ -71,6 +72,11 @@ export const colors = {
       text: '#6b7280',
       border: badgeTodoBg,
     },
+    high: {
+      background: '#fff7ed',
+      text: status.high,
+      border: '#fed7aa',
+    },
     default: {
       background: 'transparent',
       text: text.secondary,
@@ -88,7 +94,7 @@ export const colors = {
   avatar: {
     background: text.primary,
     text: surface.primary,
-    profileBackground: surface.secondary,
+    profileBackground: surface.muted,
     profileText: text.primary,
     profileBorder: border.default,
   },

--- a/packages/ds/src/tokens/typography.ts
+++ b/packages/ds/src/tokens/typography.ts
@@ -150,7 +150,7 @@ export const typographyScale = {
     lineHeight: '1',
   },
   avatarSmInitial: {
-    fontSize: '8px',
+    fontSize: '10px',
     fontFamily: fontFamilies.mono,
     fontWeight: fontWeights.bold,
     letterSpacing: 'normal',


### PR DESCRIPTION
<img width="2003" height="1409" alt="tickettitleblock" src="https://github.com/user-attachments/assets/277b7b52-7f71-4832-b137-f45168df471e" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive UI work, but it also changes shared design tokens (badge colors, avatar profile background, and small avatar typography) which can cause subtle visual regressions across consumers.
> 
> **Overview**
> Adds a new `TicketTitleBlock` component (exported from the package) that renders a page-level `h1` with an optional “meta” row for status `Badge`s and an avatar slot, plus Storybook stories and a test suite validating rendering/ref forwarding/attribute passthrough.
> 
> Extends `Badge` with a new `high` variant (CSS + Storybook) and introduces corresponding color tokens; also tweaks avatar styling by switching profile background to a muted surface token and increasing small-avatar initial font size, and simplifies `Avatar` sizing class application to use `styles[size]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7bab58c9c7b26b4d26b0dc2706bcb582f2c536c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->