### PR TITLE
feat(avatar-group): add AvatarGroup with dynamic z-index

### DIFF
--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.module.css
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.module.css
@@ -1,0 +1,16 @@
+.group {
+  display: inline-flex;
+  align-items: center;
+  isolation: isolate;
+}
+
+.group > * {
+  position: relative;
+  /* First child gets the highest z-index. AvatarGroup injects
+     --ds-avatar-group-index on each child via cloneElement. */
+  z-index: calc(100 - var(--ds-avatar-group-index, 0));
+}
+
+.group > * + * {
+  margin-left: calc(-1 * var(--ds-space-scale-sm));
+}

--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { AvatarGroup } from './AvatarGroup';
+import { Avatar } from '../Avatar';
+
+const meta: Meta<typeof AvatarGroup> = {
+  title: 'Components/AvatarGroup',
+  component: AvatarGroup,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A stacking container for multiple `Avatar` elements. Each subsequent child overlaps the previous one slightly. The `profile` variant works best inside a group because its border creates visual separation between overlapping avatars.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof AvatarGroup>;
+
+export const Two: Story = {
+  render: () => (
+    <AvatarGroup aria-label="Assignees">
+      <Avatar initial="AP" aria-label="Ale P." variant="profile" size="sm" />
+      <Avatar initial="JD" aria-label="Jordan D." variant="profile" size="sm" />
+    </AvatarGroup>
+  ),
+};
+
+export const Three: Story = {
+  render: () => (
+    <AvatarGroup aria-label="Assignees">
+      <Avatar initial="AP" aria-label="Ale P." variant="profile" size="sm" />
+      <Avatar initial="JD" aria-label="Jordan D." variant="profile" size="sm" />
+      <Avatar initial="AM" aria-label="Alex M." variant="profile" size="sm" />
+    </AvatarGroup>
+  ),
+};
+
+export const MediumSize: Story = {
+  render: () => (
+    <AvatarGroup aria-label="Team members">
+      <Avatar
+        initial="AH"
+        aria-label="Alex H."
+        variant="profile"
+        style={{ backgroundColor: '#7D9B84' }}
+      />
+      <Avatar
+        initial="CH"
+        aria-label="Cleo H."
+        variant="profile"
+        style={{ backgroundColor: '#C38E70' }}
+      />
+      <Avatar
+        initial="VP"
+        aria-label="Vader P."
+        variant="profile"
+        style={{ backgroundColor: '#6C89A8' }}
+      />
+    </AvatarGroup>
+  ),
+};

--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { AvatarGroup } from './AvatarGroup';
+import { Avatar } from '../Avatar';
+
+describe('AvatarGroup', () => {
+  it('renders all child avatars', () => {
+    render(
+      <AvatarGroup aria-label="Assignees">
+        <Avatar initial="AP" aria-label="Ale P." variant="profile" />
+        <Avatar initial="JD" aria-label="Jordan D." variant="profile" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByLabelText('Ale P.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Jordan D.')).toBeInTheDocument();
+  });
+
+  it('exposes a labelled group role to assistive tech', () => {
+    render(
+      <AvatarGroup aria-label="Assignees">
+        <Avatar initial="AP" aria-label="Ale P." variant="profile" />
+      </AvatarGroup>,
+    );
+    expect(
+      screen.getByRole('group', { name: 'Assignees' }),
+    ).toBeInTheDocument();
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    render(
+      <AvatarGroup ref={ref} aria-label="Assignees">
+        <Avatar initial="AP" aria-label="Ale P." variant="profile" />
+      </AvatarGroup>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges custom className onto the root element', () => {
+    const { container } = render(
+      <AvatarGroup aria-label="Assignees" className="custom">
+        <Avatar initial="AP" aria-label="Ale P." variant="profile" />
+      </AvatarGroup>,
+    );
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes onto the root element', () => {
+    render(
+      <AvatarGroup aria-label="Assignees" data-testid="group">
+        <Avatar initial="AP" aria-label="Ale P." variant="profile" />
+      </AvatarGroup>,
+    );
+    expect(screen.getByTestId('group')).toBeInTheDocument();
+  });
+});

--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.tsx
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.tsx
@@ -1,0 +1,44 @@
+import {
+  Children,
+  cloneElement,
+  forwardRef,
+  isValidElement,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactElement,
+} from 'react';
+import { cn } from '../../utils/cn';
+import styles from './AvatarGroup.module.css';
+
+export interface AvatarGroupProps extends HTMLAttributes<HTMLDivElement> {
+  'aria-label': string;
+}
+
+type ChildWithStyle = ReactElement<{ style?: CSSProperties }>;
+
+export const AvatarGroup = forwardRef<HTMLDivElement, AvatarGroupProps>(
+  ({ children, className, ...rest }, ref) => {
+    const items = Children.toArray(children).filter(isValidElement);
+
+    return (
+      <div
+        ref={ref}
+        role="group"
+        className={cn(styles.group, className)}
+        {...rest}
+      >
+        {items.map((child, index) => {
+          const typed = child as ChildWithStyle;
+          return cloneElement(typed, {
+            style: {
+              ...typed.props.style,
+              '--ds-avatar-group-index': index,
+            } as CSSProperties,
+          });
+        })}
+      </div>
+    );
+  },
+);
+
+AvatarGroup.displayName = 'AvatarGroup';

--- a/packages/ds/src/components/AvatarGroup/index.ts
+++ b/packages/ds/src/components/AvatarGroup/index.ts
@@ -1,0 +1,1 @@
+export { AvatarGroup, type AvatarGroupProps } from './AvatarGroup';

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { TicketTitleBlock } from './TicketTitleBlock';
 import { Avatar } from '../Avatar';
+import { AvatarGroup } from '../AvatarGroup';
 
 const meta: Meta<typeof TicketTitleBlock> = {
   title: 'Components/TicketTitleBlock',
@@ -63,5 +64,33 @@ export const WithoutBadges: Story = {
 export const TitleOnly: Story = {
   args: {
     title: ticketTitle,
+  },
+};
+
+export const WithAvatarGroup: Story = {
+  args: {
+    title: ticketTitle,
+    badges: [
+      { label: 'In Progress', variant: 'progress' },
+      { label: 'High Prio', variant: 'high' },
+    ],
+    avatar: (
+      <AvatarGroup aria-label="Assignees">
+        <Avatar
+          initial="JD"
+          aria-label="Jordan D."
+          variant="profile"
+          size="sm"
+          style={{ backgroundColor: '#6C89A8' }}
+        />
+        <Avatar
+          initial="AM"
+          aria-label="Alex M."
+          variant="profile"
+          size="sm"
+          style={{ backgroundColor: '#C38E70' }}
+        />
+      </AvatarGroup>
+    ),
   },
 };

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -35,6 +35,7 @@ export {
   iconRegistry,
 } from './icons';
 export { Avatar, type AvatarProps } from './components/Avatar';
+export { AvatarGroup, type AvatarGroupProps } from './components/AvatarGroup';
 export { StatusDot, type StatusDotProps } from './components/StatusDot';
 export { Badge, type BadgeProps } from './components/Badge';
 export { NavItem, type NavItemProps } from './components/NavItem';

--- a/packages/ds/src/tokens/typography.ts
+++ b/packages/ds/src/tokens/typography.ts
@@ -152,7 +152,7 @@ export const typographyScale = {
   avatarSmInitial: {
     fontSize: '10px',
     fontFamily: fontFamilies.mono,
-    fontWeight: fontWeights.bold,
+    fontWeight: fontWeights.medium,
     letterSpacing: 'normal',
     textTransform: 'none',
     lineHeight: '1',


### PR DESCRIPTION
<img width="1628" height="1411" alt="avatar-group" src="https://github.com/user-attachments/assets/a3ab0cf1-a096-48f6-8734-575413c3f3c6" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive (new `AvatarGroup` component, stories, and tests), but it also changes the `avatarSmInitial` typography token weight which may subtly affect avatar rendering across consumers.
> 
> **Overview**
> Adds a new `AvatarGroup` component that stacks child avatars with negative spacing and deterministic layering by injecting a per-child `--ds-avatar-group-index` style and using it to compute `z-index`.
> 
> Includes Storybook docs/examples (and a `TicketTitleBlock` story demonstrating grouped assignees), plus a small test suite for accessibility/ref forwarding/prop passthrough, exports `AvatarGroup` from the DS entrypoint, and tweaks `typographyScale.avatarSmInitial` from `bold` to `medium`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de5685c82f6db59bdf13001d3f4a5b3a728974bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->