### PR TITLE
refactor(tests): align ref pattern with createRef

### DIFF
--- a/packages/ds/src/components/Avatar/Avatar.test.tsx
+++ b/packages/ds/src/components/Avatar/Avatar.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Avatar } from './Avatar';
@@ -15,7 +16,7 @@ describe('Avatar', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<Avatar ref={ref} initial="P" aria-label="Project P" />);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { AvatarGroup } from './AvatarGroup';
@@ -27,7 +28,7 @@ describe('AvatarGroup', () => {
   });
 
   it('forwards ref to the root element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <AvatarGroup ref={ref} aria-label="Assignees">
         <Avatar initial="AP" aria-label="Ale P." variant="profile" />

--- a/packages/ds/src/components/Badge/Badge.test.tsx
+++ b/packages/ds/src/components/Badge/Badge.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Badge } from './Badge';
@@ -19,7 +20,7 @@ describe('Badge', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<Badge ref={ref}>Label</Badge>);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/ds/src/components/BottomSheet/BottomSheet.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { BottomSheet } from './BottomSheet';
@@ -133,7 +134,7 @@ describe('BottomSheet', () => {
   });
 
   it('forwards ref to the panel element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <BottomSheet ref={ref} open onClose={vi.fn()} aria-label="Test">
         content

--- a/packages/ds/src/components/BottomTabBar/BottomTabBar.test.tsx
+++ b/packages/ds/src/components/BottomTabBar/BottomTabBar.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { BottomTabBar } from './BottomTabBar';
@@ -42,7 +43,7 @@ describe('BottomTabBar', () => {
   });
 
   it('forwards ref to the nav element', () => {
-    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    const ref = createRef<HTMLElement>();
     render(
       <BottomTabBar ref={ref} aria-label="Main navigation">
         <NavItem

--- a/packages/ds/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/ds/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Breadcrumb } from './Breadcrumb';
@@ -43,7 +44,7 @@ describe('Breadcrumb', () => {
   });
 
   it('forwards ref to the nav element', () => {
-    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    const ref = createRef<HTMLElement>();
     render(<Breadcrumb ref={ref} segments={segments} />);
     expect(ref.current).toBeInstanceOf(HTMLElement);
     expect(ref.current?.tagName).toBe('NAV');

--- a/packages/ds/src/components/Button/Button.test.tsx
+++ b/packages/ds/src/components/Button/Button.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
@@ -12,7 +13,7 @@ describe('Button', () => {
   });
 
   it('forwards ref to the button element', () => {
-    const ref = { current: null } as React.RefObject<HTMLButtonElement | null>;
+    const ref = createRef<HTMLButtonElement>();
     render(<Button ref={ref}>Ref test</Button>);
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/packages/ds/src/components/Card/Card.test.tsx
+++ b/packages/ds/src/components/Card/Card.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Card } from './Card';
@@ -49,7 +50,7 @@ describe('Card', () => {
   });
 
   it('forwards ref to the root element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <Card ref={ref}>
         <p>Body</p>

--- a/packages/ds/src/components/Checkbox/Checkbox.test.tsx
+++ b/packages/ds/src/components/Checkbox/Checkbox.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
@@ -43,7 +44,7 @@ describe('Checkbox', () => {
   });
 
   it('forwards ref to the input element', () => {
-    const ref = { current: null } as React.RefObject<HTMLInputElement | null>;
+    const ref = createRef<HTMLInputElement>();
     render(<Checkbox ref={ref} aria-label="Toggle task" />);
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
   });

--- a/packages/ds/src/components/ChecklistRow/ChecklistRow.test.tsx
+++ b/packages/ds/src/components/ChecklistRow/ChecklistRow.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ChecklistRow } from './ChecklistRow';
@@ -125,7 +126,7 @@ describe('ChecklistRow', () => {
   });
 
   it('forwards ref to the root element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(<ChecklistRow ref={ref} status="passed" label="Cache hit" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/ds/src/components/DateCell/DateCell.test.tsx
+++ b/packages/ds/src/components/DateCell/DateCell.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { DateCell } from './DateCell';
@@ -26,7 +27,7 @@ describe('DateCell', () => {
   });
 
   it('forwards ref to the time element', () => {
-    const ref = { current: null } as React.RefObject<HTMLTimeElement | null>;
+    const ref = createRef<HTMLTimeElement>();
     render(<DateCell ref={ref} date="Oct 28" dateTime="2026-10-28" />);
     expect(ref.current).toBeInstanceOf(HTMLTimeElement);
   });

--- a/packages/ds/src/components/Drawer/Drawer.test.tsx
+++ b/packages/ds/src/components/Drawer/Drawer.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Drawer } from './Drawer';
@@ -118,7 +119,7 @@ describe('Drawer', () => {
   });
 
   it('forwards ref to the panel element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <Drawer ref={ref} open onClose={vi.fn()} aria-label="Test">
         content

--- a/packages/ds/src/components/Fab/Fab.test.tsx
+++ b/packages/ds/src/components/Fab/Fab.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
@@ -13,7 +14,7 @@ describe('Fab', () => {
   });
 
   it('forwards ref to the button element', () => {
-    const ref = { current: null } as React.RefObject<HTMLButtonElement | null>;
+    const ref = createRef<HTMLButtonElement>();
     render(<Fab ref={ref} aria-label="New task" />);
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/packages/ds/src/components/FloatingSearch/FloatingSearch.test.tsx
+++ b/packages/ds/src/components/FloatingSearch/FloatingSearch.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { FloatingSearch } from './FloatingSearch';
@@ -9,7 +10,7 @@ describe('FloatingSearch', () => {
   });
 
   it('forwards ref to input element', () => {
-    const ref = { current: null } as React.RefObject<HTMLInputElement | null>;
+    const ref = createRef<HTMLInputElement>();
     render(<FloatingSearch ref={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
   });

--- a/packages/ds/src/components/Header/Header.test.tsx
+++ b/packages/ds/src/components/Header/Header.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Header } from './Header';
@@ -48,7 +49,7 @@ describe('Header', () => {
   });
 
   it('forwards ref to header element', () => {
-    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    const ref = createRef<HTMLElement>();
     render(<Header ref={ref} />);
     expect(ref.current).toBeInstanceOf(HTMLElement);
     expect(ref.current?.tagName).toBe('HEADER');

--- a/packages/ds/src/components/Icon/Icon.test.tsx
+++ b/packages/ds/src/components/Icon/Icon.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Icon } from './Icon';
@@ -44,7 +45,7 @@ describe('Icon', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<Icon ref={ref} name="task_alt" />);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/IconButton/IconButton.test.tsx
+++ b/packages/ds/src/components/IconButton/IconButton.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
@@ -12,7 +13,7 @@ describe('IconButton', () => {
   });
 
   it('forwards ref to the button element', () => {
-    const ref = { current: null } as React.RefObject<HTMLButtonElement | null>;
+    const ref = createRef<HTMLButtonElement>();
     render(<IconButton ref={ref} icon="menu" aria-label="Menu" />);
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });

--- a/packages/ds/src/components/NavItem/NavItem.test.tsx
+++ b/packages/ds/src/components/NavItem/NavItem.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { NavItem } from './NavItem';
@@ -45,7 +46,7 @@ describe('NavItem', () => {
   });
 
   it('forwards ref to the anchor element', () => {
-    const ref = { current: null } as React.RefObject<HTMLAnchorElement | null>;
+    const ref = createRef<HTMLAnchorElement>();
     render(<NavItem ref={ref} icon="task_alt" label="Tasks" href="/tasks" />);
     expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
   });

--- a/packages/ds/src/components/PriorityLabel/PriorityLabel.test.tsx
+++ b/packages/ds/src/components/PriorityLabel/PriorityLabel.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { PriorityLabel } from './PriorityLabel';
@@ -23,7 +24,7 @@ describe('PriorityLabel', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<PriorityLabel ref={ref} priority="high" />);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/ProjectPicker/ProjectPicker.test.tsx
+++ b/packages/ds/src/components/ProjectPicker/ProjectPicker.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ProjectPicker, type ProjectPickerProject } from './ProjectPicker';
@@ -122,7 +123,7 @@ describe('ProjectPicker', () => {
   });
 
   it('forwards ref to root element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <ProjectPicker
         ref={ref}

--- a/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { PropertyRow } from './PropertyRow';
@@ -53,7 +54,7 @@ describe('PropertyRow', () => {
   });
 
   it('forwards ref', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <PropertyRow ref={ref} icon="person" label="Assignee">
         Alex D.

--- a/packages/ds/src/components/RecentTaskList/RecentTaskList.test.tsx
+++ b/packages/ds/src/components/RecentTaskList/RecentTaskList.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { RecentTaskList } from './RecentTaskList';
@@ -30,7 +31,7 @@ describe('RecentTaskList', () => {
   });
 
   it('forwards ref', () => {
-    const ref = { current: null } as React.RefObject<HTMLUListElement | null>;
+    const ref = createRef<HTMLUListElement>();
     render(<RecentTaskList ref={ref} items={items} />);
     expect(ref.current).toBeInstanceOf(HTMLUListElement);
   });

--- a/packages/ds/src/components/RefLabel/RefLabel.test.tsx
+++ b/packages/ds/src/components/RefLabel/RefLabel.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { RefLabel } from './RefLabel';
@@ -34,7 +35,7 @@ describe('RefLabel', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<RefLabel ref={ref}>Label</RefLabel>);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/SearchInput/SearchInput.test.tsx
+++ b/packages/ds/src/components/SearchInput/SearchInput.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
@@ -10,7 +11,7 @@ describe('SearchInput', () => {
   });
 
   it('forwards ref to the input element', () => {
-    const ref = { current: null } as React.RefObject<HTMLInputElement | null>;
+    const ref = createRef<HTMLInputElement>();
     render(<SearchInput ref={ref} aria-label="Search tasks" />);
     expect(ref.current).toBeInstanceOf(HTMLInputElement);
   });

--- a/packages/ds/src/components/SectionHeader/SectionHeader.test.tsx
+++ b/packages/ds/src/components/SectionHeader/SectionHeader.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { SectionHeader } from './SectionHeader';
@@ -23,7 +24,7 @@ describe('SectionHeader', () => {
   });
 
   it('forwards ref to the container div element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(<SectionHeader ref={ref}>Label</SectionHeader>);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/ds/src/components/Selector/Selector.test.tsx
+++ b/packages/ds/src/components/Selector/Selector.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi } from 'vitest';
@@ -158,7 +159,7 @@ describe('Selector', () => {
   });
 
   it('forwards ref to container div', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(<Selector ref={ref} options={options} value="a" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/ds/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/ds/src/components/Sidebar/Sidebar.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { Sidebar } from './Sidebar';
@@ -70,7 +71,7 @@ describe('Sidebar', () => {
   });
 
   it('forwards ref to aside element', () => {
-    const ref = { current: null } as React.RefObject<HTMLElement | null>;
+    const ref = createRef<HTMLElement>();
     render(
       <Sidebar ref={ref} aria-label="Sidebar navigation">
         <a href="/link">Link</a>

--- a/packages/ds/src/components/StatusDot/StatusDot.test.tsx
+++ b/packages/ds/src/components/StatusDot/StatusDot.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { StatusDot } from './StatusDot';
@@ -19,7 +20,7 @@ describe('StatusDot', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<StatusDot ref={ref} label="Active" />);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ds/src/components/Tabs/Tabs.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { Tabs, type TabItem } from './Tabs';
@@ -209,7 +210,7 @@ describe('Tabs', () => {
   });
 
   it('forwards ref to the tablist element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <Tabs
         ref={ref}

--- a/packages/ds/src/components/TaskDrawer/TaskDrawer.test.tsx
+++ b/packages/ds/src/components/TaskDrawer/TaskDrawer.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { TaskDrawer, TaskDrawerField, TaskDrawerSection } from './TaskDrawer';
@@ -88,7 +89,7 @@ describe('TaskDrawer', () => {
   });
 
   it('forwards ref', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(
       <TaskDrawer ref={ref} title="Test" onCancel={vi.fn()} onSubmit={vi.fn()}>
         content

--- a/packages/ds/src/components/TaskRow/TaskRow.test.tsx
+++ b/packages/ds/src/components/TaskRow/TaskRow.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
@@ -127,7 +128,7 @@ describe('TaskRow', () => {
   });
 
   it('forwards ref to the div element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(<TaskRow ref={ref} title="Fix login bug" refId="TSK-1" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });

--- a/packages/ds/src/components/TaskSection/TaskSection.test.tsx
+++ b/packages/ds/src/components/TaskSection/TaskSection.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';
@@ -50,9 +51,7 @@ describe('TaskSection', () => {
   });
 
   it('forwards ref to the details element', () => {
-    const ref = {
-      current: null,
-    } as React.RefObject<HTMLDetailsElement | null>;
+    const ref = createRef<HTMLDetailsElement>();
     render(
       <TaskSection ref={ref} title="ACTIVE TASKS">
         <p>Content</p>

--- a/packages/ds/src/components/TicketId/TicketId.test.tsx
+++ b/packages/ds/src/components/TicketId/TicketId.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { TicketId } from './TicketId';
@@ -9,7 +10,7 @@ describe('TicketId', () => {
   });
 
   it('forwards ref to the span element', () => {
-    const ref = { current: null } as React.RefObject<HTMLSpanElement | null>;
+    const ref = createRef<HTMLSpanElement>();
     render(<TicketId ref={ref}>ENG-902</TicketId>);
     expect(ref.current).toBeInstanceOf(HTMLSpanElement);
   });

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.test.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.test.tsx
@@ -1,3 +1,4 @@
+import { createRef } from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { TicketTitleBlock } from './TicketTitleBlock';
@@ -62,7 +63,7 @@ describe('TicketTitleBlock', () => {
   });
 
   it('forwards ref to the root element', () => {
-    const ref = { current: null } as React.RefObject<HTMLDivElement | null>;
+    const ref = createRef<HTMLDivElement>();
     render(<TicketTitleBlock ref={ref} title="Edge caching" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to test ref setup/typing and do not affect runtime component behavior.
> 
> **Overview**
> Updates the design-system component tests to **standardize ref-forwarding assertions** by switching from manually cast `RefObject` literals to `createRef()`.
> 
> This change is applied across many component test suites (e.g., `Avatar`, `BottomSheet`, `Tabs`, `TaskRow`) and only affects test code/typing, not component implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4a946f8952c07bfe18cb9bb83cb1d263f40e0b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->