### PR TITLE
feat(pipeline-stage-indicator): add read-only pipeline stage summary …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "name": "tasksgo-ui",
-      "hasInstallScript": true,
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -5108,19 +5107,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5429,44 +5415,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -5707,47 +5655,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
@@ -5864,19 +5771,6 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -8018,26 +7912,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/icss-replace-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
-      "integrity": "sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/icss-utils": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8229,19 +8103,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -8623,13 +8484,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-there": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/is-there/-/is-there-4.5.2.tgz",
-      "integrity": "sha512-ixMkfz3rtS1vEsLf0TjgjqUn96Q0ukpUVDMnPYVocJyTzu2G/QgEtqYddcHZawHO+R31cKVPggJmBLrm1vJCOg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
@@ -11838,90 +11692,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-modules-extract-imports": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
-      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-local-by-default": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
-      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "icss-utils": "^5.0.0",
-        "postcss-selector-parser": "^7.0.0",
-        "postcss-value-parser": "^4.1.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-scope": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
-      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "postcss-selector-parser": "^7.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-modules-values": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "icss-utils": "^5.0.0"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >= 14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -12134,19 +11904,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
       }
     },
     "node_modules/recast": {
@@ -12665,19 +12422,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -13760,152 +13504,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/typed-css-modules": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.9.1.tgz",
-      "integrity": "sha512-W2HWKncdKd+bLWsnuWB2EyuQBzZ7KJ9Byr/67KLiiyGegcN52rOveun9JR8yAvuL5IXunRMxt0eORMtAUj5bmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "chalk": "^4.0.0",
-        "chokidar": "^3.4.0",
-        "glob": "^10.3.10",
-        "icss-replace-symbols": "^1.1.0",
-        "is-there": "^4.4.2",
-        "mkdirp": "^3.0.0",
-        "postcss": "^8.0.0",
-        "postcss-modules-extract-imports": "^3.0.0",
-        "postcss-modules-local-by-default": "^4.0.0",
-        "postcss-modules-scope": "^3.0.0",
-        "postcss-modules-values": "^4.0.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "tcm": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/typed-css-modules/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/mkdirp": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
-      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "dist/cjs/src/bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/typed-css-modules/node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -15083,7 +14681,6 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "axe-playwright": "^2.2.2",
-        "concurrently": "^9.2.1",
         "eslint": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -15092,7 +14689,6 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.2.0",
-        "typed-css-modules": "^0.9.1",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.56.1",
         "vite": "^7.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "tasksgo-ui",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -5107,6 +5108,19 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5415,6 +5429,44 @@
         "node": ">= 16"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/ci-info": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -5655,6 +5707,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concurrently": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "rxjs": "7.8.2",
+        "shell-quote": "1.8.3",
+        "supports-color": "8.1.1",
+        "tree-kill": "1.2.2",
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
@@ -5771,6 +5864,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -7912,6 +8018,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icss-replace-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
+      "integrity": "sha512-chIaY3Vh2mh2Q3RGXttaDIzeiPvaVXJ+C4DAh/w3c37SKZ/U6PGMmuicR2EQQp9bKG8zLMCl7I+PtIoOOPp8Gg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8103,6 +8229,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-boolean-object": {
@@ -8484,6 +8623,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-there": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/is-there/-/is-there-4.5.2.tgz",
+      "integrity": "sha512-ixMkfz3rtS1vEsLf0TjgjqUn96Q0ukpUVDMnPYVocJyTzu2G/QgEtqYddcHZawHO+R31cKVPggJmBLrm1vJCOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
@@ -11692,6 +11838,90 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11904,6 +12134,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/recast": {
@@ -12422,6 +12665,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -13504,6 +13760,152 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-css-modules": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.9.1.tgz",
+      "integrity": "sha512-W2HWKncdKd+bLWsnuWB2EyuQBzZ7KJ9Byr/67KLiiyGegcN52rOveun9JR8yAvuL5IXunRMxt0eORMtAUj5bmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "chalk": "^4.0.0",
+        "chokidar": "^3.4.0",
+        "glob": "^10.3.10",
+        "icss-replace-symbols": "^1.1.0",
+        "is-there": "^4.4.2",
+        "mkdirp": "^3.0.0",
+        "postcss": "^8.0.0",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "tcm": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/typed-css-modules/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/typed-css-modules/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typedarray-to-buffer": {
@@ -14681,6 +15083,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "axe-playwright": "^2.2.2",
+        "concurrently": "^9.2.1",
         "eslint": "^9.0.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -14689,6 +15092,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "storybook": "^10.2.0",
+        "typed-css-modules": "^0.9.1",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.56.1",
         "vite": "^7.0.0",

--- a/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.module.css
+++ b/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.module.css
@@ -33,7 +33,7 @@
 }
 
 .separator {
-  color: var(--ds-color-text-disabled);
+  color: var(--ds-color-text-secondary);
   font-size: var(--ds-text-badge-label-font-size);
   letter-spacing: 1px;
   user-select: none;

--- a/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.module.css
+++ b/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.module.css
@@ -1,0 +1,40 @@
+.group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-scale-sm);
+}
+
+.stage {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--ds-space-badge-padding-y) var(--ds-space-badge-padding-x);
+  border-radius: var(--ds-radius-full);
+  border: 1px solid transparent;
+  background-color: transparent;
+  color: var(--ds-color-text-secondary);
+  font-size: var(--ds-text-badge-label-font-size);
+  font-family: var(--ds-text-badge-label-font-family);
+  font-weight: var(--ds-text-badge-label-font-weight);
+  letter-spacing: var(--ds-text-badge-label-letter-spacing);
+  text-transform: var(--ds-text-badge-label-text-transform);
+  line-height: var(--ds-text-badge-label-line-height);
+  white-space: nowrap;
+}
+
+.active {
+  background-color: var(--ds-color-badge-todo-background);
+  color: var(--ds-color-text-primary);
+  border-color: var(--ds-color-badge-todo-border);
+}
+
+/* Declared after .active so disabled wins when a stage is both active and disabled. */
+.disabled {
+  color: var(--ds-color-text-disabled);
+}
+
+.separator {
+  color: var(--ds-color-text-disabled);
+  font-size: var(--ds-text-badge-label-font-size);
+  letter-spacing: 1px;
+  user-select: none;
+}

--- a/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.stories.tsx
+++ b/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { PipelineStageIndicator } from './PipelineStageIndicator';
+
+const meta: Meta<typeof PipelineStageIndicator> = {
+  title: 'Components/PipelineStageIndicator',
+  component: PipelineStageIndicator,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A read-only summary of pipeline stages with the active stage visually highlighted. The active value is decided by the consumer and announced via `aria-current="step"`. When more than three stages are provided, only the first, middle (closest to half of the length), and last are shown — pair with a popover or full list to expose the rest. When the active value would otherwise be hidden, it overrides the computed middle so it stays visible.',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '24px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof PipelineStageIndicator>;
+
+export const TwoStages: Story = {
+  args: {
+    items: [
+      { value: 'staging', label: 'Staging' },
+      { value: 'prod', label: 'Prod' },
+    ],
+    value: 'staging',
+    'aria-label': 'Environment',
+  },
+};
+
+export const ThreeStages: Story = {
+  args: {
+    items: [
+      { value: 'qa1', label: 'QA1' },
+      { value: 'qa2', label: 'QA2' },
+      { value: 'prod', label: 'Prod' },
+    ],
+    value: 'qa2',
+    'aria-label': 'Environment',
+  },
+};
+
+export const FourStagesAbbreviated: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With 4 stages, only first + middle (index 2, `Math.floor(4/2)`) + last are shown.',
+      },
+    },
+  },
+  args: {
+    items: [
+      { value: 'qa1', label: 'QA1' },
+      { value: 'qa2', label: 'QA2' },
+      { value: 'staging', label: 'Staging' },
+      { value: 'prod', label: 'Prod' },
+    ],
+    value: 'staging',
+    'aria-label': 'Environment',
+  },
+};
+
+export const FiveStagesAbbreviated: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With 5 stages, only first + middle (index 2, `Math.floor(5/2)`) + last are shown.',
+      },
+    },
+  },
+  args: {
+    items: [
+      { value: 'qa1', label: 'QA1' },
+      { value: 'qa2', label: 'QA2' },
+      { value: 'qa3', label: 'QA3' },
+      { value: 'staging', label: 'Staging' },
+      { value: 'prod', label: 'Prod' },
+    ],
+    value: 'qa3',
+    'aria-label': 'Environment',
+  },
+};
+
+export const WithDisabledStage: Story = {
+  args: {
+    items: [
+      { value: 'qa1', label: 'QA1' },
+      { value: 'qa2', label: 'QA2', disabled: true },
+      { value: 'prod', label: 'Prod' },
+    ],
+    value: 'qa1',
+    'aria-label': 'Environment',
+  },
+};

--- a/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.test.tsx
+++ b/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.test.tsx
@@ -1,0 +1,328 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import {
+  PipelineStageIndicator,
+  type PipelineStage,
+} from './PipelineStageIndicator';
+
+const items: readonly PipelineStage[] = [
+  { value: 'qa1', label: 'QA1' },
+  { value: 'qa2', label: 'QA2' },
+  { value: 'prod', label: 'Prod' },
+];
+
+describe('PipelineStageIndicator', () => {
+  it('renders each visible stage label', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa2"
+        aria-label="Environment"
+      />,
+    );
+    expect(screen.getByText('QA1')).toBeInTheDocument();
+    expect(screen.getByText('QA2')).toBeInTheDocument();
+    expect(screen.getByText('Prod')).toBeInTheDocument();
+  });
+
+  it('marks the active stage with aria-current="step"', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa2"
+        aria-label="Environment"
+      />,
+    );
+    expect(screen.getByText('QA2')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('does not set aria-current on inactive stages', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa2"
+        aria-label="Environment"
+      />,
+    );
+    expect(screen.getByText('QA1')).not.toHaveAttribute('aria-current');
+    expect(screen.getByText('Prod')).not.toHaveAttribute('aria-current');
+  });
+
+  it('renders no aria-current when value matches no item', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="nonexistent"
+        aria-label="Environment"
+      />,
+    );
+    items.forEach((item) => {
+      expect(screen.getByText(item.label)).not.toHaveAttribute('aria-current');
+    });
+  });
+
+  it('exposes a labelled group role to assistive tech', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa1"
+        aria-label="Environment"
+      />,
+    );
+    expect(
+      screen.getByRole('group', { name: 'Environment' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows all items when items.length is 2', () => {
+    const twoItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+    ];
+    render(
+      <PipelineStageIndicator items={twoItems} value="a" aria-label="Stages" />,
+    );
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+  });
+
+  it('shows all items when items.length is 3', () => {
+    render(
+      <PipelineStageIndicator items={items} value="qa1" aria-label="Stages" />,
+    );
+    expect(screen.getAllByText(/QA1|QA2|Prod/)).toHaveLength(3);
+  });
+
+  it('abbreviates to first + computed middle + last when items.length is 4 and active is first', () => {
+    const fourItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fourItems}
+        value="a"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('A')).toBeInTheDocument();
+    // Math.floor(4 / 2) = 2 — middle is C
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+  });
+
+  it('abbreviates to first + computed middle + last when items.length is 5 and active is first', () => {
+    const fiveItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fiveItems}
+        value="a"
+        aria-label="Stages"
+      />,
+    );
+    // Math.floor(5 / 2) = 2 — middle is C
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('E')).toBeInTheDocument();
+  });
+
+  it('abbreviates to first + computed middle + last when items.length is 6 and active is first', () => {
+    const sixItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+      { value: 'f', label: 'F' },
+    ];
+    render(
+      <PipelineStageIndicator items={sixItems} value="a" aria-label="Stages" />,
+    );
+    // Math.floor(6 / 2) = 3 — middle is D
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
+    expect(screen.getByText('F')).toBeInTheDocument();
+  });
+
+  it('puts the active item in the middle slot when it would otherwise be hidden (length=5, active=B)', () => {
+    const fiveItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fiveItems}
+        value="b"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('E')).toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.queryByText('D')).not.toBeInTheDocument();
+    expect(screen.getByText('B')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('puts the active item in the middle slot when it would otherwise be hidden (length=5, active=D)', () => {
+    const fiveItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fiveItems}
+        value="d"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
+    expect(screen.getByText('E')).toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+    expect(screen.getByText('D')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('keeps the default middle when the active item is the first', () => {
+    const fiveItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fiveItems}
+        value="a"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('A')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('keeps the default middle when the active item is the last', () => {
+    const fiveItems: readonly PipelineStage[] = [
+      { value: 'a', label: 'A' },
+      { value: 'b', label: 'B' },
+      { value: 'c', label: 'C' },
+      { value: 'd', label: 'D' },
+      { value: 'e', label: 'E' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={fiveItems}
+        value="e"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('E')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('renders no stage labels when items is empty', () => {
+    const { container } = render(
+      <PipelineStageIndicator items={[]} value="" aria-label="Stages" />,
+    );
+    expect(screen.getByRole('group', { name: 'Stages' })).toBeInTheDocument();
+    // No stage spans rendered — only the root div
+    expect(container.firstChild?.childNodes).toHaveLength(0);
+  });
+
+  it('renders a single stage with no separator when items.length is 1', () => {
+    render(
+      <PipelineStageIndicator
+        items={[{ value: 'only', label: 'Only' }]}
+        value="only"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('Only')).toBeInTheDocument();
+    expect(screen.getByText('Only')).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('sets aria-disabled on disabled stages', () => {
+    const withDisabled: readonly PipelineStage[] = [
+      { value: 'qa1', label: 'QA1' },
+      { value: 'qa2', label: 'QA2', disabled: true },
+      { value: 'prod', label: 'Prod' },
+    ];
+    render(
+      <PipelineStageIndicator
+        items={withDisabled}
+        value="qa1"
+        aria-label="Stages"
+      />,
+    );
+    expect(screen.getByText('QA2')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByText('QA1')).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('renders no buttons or interactive elements', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa2"
+        aria-label="Environment"
+      />,
+    );
+    expect(screen.queryAllByRole('button')).toHaveLength(0);
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+    expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <PipelineStageIndicator
+        ref={ref}
+        items={items}
+        value="qa1"
+        aria-label="Environment"
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('merges custom className onto the root element', () => {
+    const { container } = render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa1"
+        aria-label="Environment"
+        className="custom"
+      />,
+    );
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes onto the root element', () => {
+    render(
+      <PipelineStageIndicator
+        items={items}
+        value="qa1"
+        aria-label="Environment"
+        data-testid="pipeline"
+      />,
+    );
+    expect(screen.getByTestId('pipeline')).toBeInTheDocument();
+  });
+});

--- a/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.tsx
+++ b/packages/ds/src/components/PipelineStageIndicator/PipelineStageIndicator.tsx
@@ -1,0 +1,73 @@
+import { Fragment, forwardRef, type HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+import styles from './PipelineStageIndicator.module.css';
+
+export interface PipelineStage {
+  value: string;
+  label: string;
+  disabled?: boolean;
+}
+
+export interface PipelineStageIndicatorProps extends HTMLAttributes<HTMLDivElement> {
+  items: readonly PipelineStage[];
+  value: string;
+  'aria-label': string;
+}
+
+function getVisibleItems(
+  items: readonly PipelineStage[],
+  value: string,
+): readonly PipelineStage[] {
+  if (items.length <= 3) return items;
+  const first = items[0];
+  const last = items[items.length - 1];
+  const activeIndex = items.findIndex((it) => it.value === value);
+  const middleIndex =
+    activeIndex > 0 && activeIndex < items.length - 1
+      ? activeIndex
+      : Math.floor(items.length / 2);
+  return [first, items[middleIndex], last];
+}
+
+export const PipelineStageIndicator = forwardRef<
+  HTMLDivElement,
+  PipelineStageIndicatorProps
+>(({ items, value, 'aria-label': ariaLabel, className, ...rest }, ref) => {
+  const visibleItems = getVisibleItems(items, value);
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-label={ariaLabel}
+      className={cn(styles.group, className)}
+      {...rest}
+    >
+      {visibleItems.map((item, index) => {
+        const active = item.value === value;
+        return (
+          <Fragment key={item.value}>
+            {index > 0 && (
+              <span className={styles.separator} aria-hidden="true">
+                ·····
+              </span>
+            )}
+            <span
+              aria-current={active ? 'step' : undefined}
+              aria-disabled={item.disabled || undefined}
+              className={cn(
+                styles.stage,
+                active && styles.active,
+                item.disabled && styles.disabled,
+              )}
+            >
+              {item.label}
+            </span>
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+});
+
+PipelineStageIndicator.displayName = 'PipelineStageIndicator';

--- a/packages/ds/src/components/PipelineStageIndicator/index.ts
+++ b/packages/ds/src/components/PipelineStageIndicator/index.ts
@@ -1,0 +1,5 @@
+export {
+  PipelineStageIndicator,
+  type PipelineStageIndicatorProps,
+  type PipelineStage,
+} from './PipelineStageIndicator';

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -118,6 +118,11 @@ export {
   type CollapsibleCardProps,
 } from './components/CollapsibleCard';
 export {
+  PipelineStageIndicator,
+  type PipelineStageIndicatorProps,
+  type PipelineStage,
+} from './components/PipelineStageIndicator';
+export {
   Tabs,
   getTabId,
   getTabPanelId,


### PR DESCRIPTION


https://github.com/user-attachments/assets/32773946-9d74-4b70-b271-126cff5d3aa9


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new, read-only design-system component plus stories/tests and exports; low risk since it doesn’t affect existing behavior beyond increasing the public API surface.
> 
> **Overview**
> Introduces a new `PipelineStageIndicator` component to the design system to display a **read-only** pipeline stage summary with an *active* stage highlighted via `aria-current="step"` and optional `aria-disabled` styling.
> 
> Includes Storybook stories and comprehensive tests covering visibility/abbreviation logic (show all for ≤3 stages; otherwise first/middle/last with active forced visible), plus exports the component/types from the package entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d799c524a8c93be4b2f7269d418410bf8630a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->