### PR TITLE
refactor(stories/pages): extract shared chrome and use Badge for vers…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
   a11y:
     runs-on: ubuntu-latest
     needs: validate
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,6 +57,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     needs: validate
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
   a11y:
     runs-on: ubuntu-latest
     needs: validate
-    timeout-minutes: 10
+    timeout-minutes: 5
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -44,7 +44,20 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install --with-deps chromium
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers and system deps (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - run: npm run build-storybook -w packages/ds
 
@@ -69,7 +82,20 @@ jobs:
 
       - run: npm ci
 
-      - run: npx playwright install --with-deps chromium
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright browsers and system deps (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system deps only (cache hit)
+        if: steps.pw-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - run: npm run build-storybook -w packages/ds
 

--- a/packages/ds/.storybook/decorators.tsx
+++ b/packages/ds/.storybook/decorators.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react';
 import type { Decorator } from '@storybook/react';
 import { useGlobals } from 'storybook/preview-api';
 
+export const VIEWPORT_APPLIED_ATTR = 'data-ds-viewport-applied';
+
 export const withDefaultViewport =
   (viewport: string): Decorator =>
   (Story, context) => {
@@ -12,6 +14,7 @@ export const withDefaultViewport =
       if (!applied.current && !isDocs) {
         applied.current = true;
         updateGlobals({ viewport: { value: viewport } });
+        document.documentElement.setAttribute(VIEWPORT_APPLIED_ATTR, viewport);
       }
     }, [updateGlobals, isDocs]);
     return <Story />;

--- a/packages/ds/.storybook/test-runner.ts
+++ b/packages/ds/.storybook/test-runner.ts
@@ -17,8 +17,21 @@ function formatResults(results: Result[]): string {
 }
 
 const config: TestRunnerConfig = {
-  async preVisit(page) {
+  async preVisit(page, context) {
     await injectAxe(page);
+
+    const storyContext = await getStoryContext(page, context);
+    const viewportOpts = storyContext.parameters?.viewport?.options as
+      | Record<string, { name?: string }>
+      | undefined;
+    const usesMobileViewportSet =
+      viewportOpts?.responsive?.name === 'Default';
+
+    if (usesMobileViewportSet) {
+      await page
+        .waitForSelector('html[data-ds-viewport-applied]', { timeout: 2000 })
+        .catch(() => {});
+    }
   },
   async postVisit(page, context) {
     await page.waitForLoadState('networkidle');

--- a/packages/ds/src/components/Badge/Badge.module.css
+++ b/packages/ds/src/components/Badge/Badge.module.css
@@ -54,3 +54,14 @@
   color: var(--ds-color-badge-success-text);
   border-color: var(--ds-color-badge-success-border);
 }
+
+.reference {
+  background-color: var(--ds-color-badge-reference-background);
+  color: var(--ds-color-badge-reference-text);
+  border-color: var(--ds-color-badge-reference-border);
+  border-radius: var(--ds-radius-lg);
+  font-family: var(--ds-font-family-mono);
+  font-size: var(--ds-text-section-header-font-size);
+  font-weight: var(--ds-font-weight-regular);
+  text-transform: none;
+}

--- a/packages/ds/src/components/Badge/Badge.stories.tsx
+++ b/packages/ds/src/components/Badge/Badge.stories.tsx
@@ -16,7 +16,10 @@ const meta = {
         'high',
         'critical',
         'success',
+        'reference',
       ],
+      description:
+        'Visual style. Status variants (progress/todo/done/high/critical/success) tint the badge by state; "reference" is a mono-styled chip for technical reference values like version IDs, build numbers, or short hashes.',
     },
     children: { control: 'text' },
   },
@@ -54,6 +57,10 @@ export const Success: Story = {
   args: { variant: 'success', children: '4/4 Passed' },
 };
 
+export const Reference: Story = {
+  args: { variant: 'reference', children: 'v4.1.0-alpha' },
+};
+
 export const AllVariants: Story = {
   render: () => (
     <div
@@ -70,6 +77,7 @@ export const AllVariants: Story = {
       <Badge variant="high">High Prio</Badge>
       <Badge variant="critical">1 Failed</Badge>
       <Badge variant="success">4/4 Passed</Badge>
+      <Badge variant="reference">v4.1.0-alpha</Badge>
     </div>
   ),
 };

--- a/packages/ds/src/components/Badge/Badge.test.tsx
+++ b/packages/ds/src/components/Badge/Badge.test.tsx
@@ -19,6 +19,11 @@ describe('Badge', () => {
     expect(screen.getByText('In Progress')).toHaveClass('progress');
   });
 
+  it('applies the reference variant class', () => {
+    render(<Badge variant="reference">v4.1.0-alpha</Badge>);
+    expect(screen.getByText('v4.1.0-alpha')).toHaveClass('reference');
+  });
+
   it('forwards ref to the span element', () => {
     const ref = createRef<HTMLSpanElement>();
     render(<Badge ref={ref}>Label</Badge>);

--- a/packages/ds/src/components/Badge/Badge.tsx
+++ b/packages/ds/src/components/Badge/Badge.tsx
@@ -9,7 +9,8 @@ type BadgeVariant =
   | 'done'
   | 'high'
   | 'critical'
-  | 'success';
+  | 'success'
+  | 'reference';
 
 export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;

--- a/packages/ds/src/stories/helpers/pageChrome.module.css
+++ b/packages/ds/src/stories/helpers/pageChrome.module.css
@@ -1,0 +1,46 @@
+.workspaceHeader {
+  margin-top: var(--ds-space-sidebar-section-gap);
+}
+
+.workspaceEyebrow {
+  font-family: var(--ds-text-section-header-font-family);
+  font-size: var(--ds-text-section-header-font-size);
+  font-weight: var(--ds-font-weight-medium);
+  letter-spacing: var(--ds-text-section-header-letter-spacing);
+  text-transform: uppercase;
+  color: var(--ds-color-text-secondary);
+}
+
+.workspaceTitle {
+  margin: var(--ds-space-scale-sm) 0;
+  font-family: var(--ds-font-family-sans);
+  font-size: var(--ds-text-page-title-font-size);
+  font-weight: var(--ds-font-weight-bold);
+  color: var(--ds-color-text-primary);
+  line-height: var(--ds-text-page-title-line-height);
+}
+
+.workspaceStatusRow {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-scale-sm);
+}
+
+.sidebarStatusLabel {
+  display: block;
+  margin-top: var(--ds-space-scale-md);
+  padding: 0 var(--ds-space-nav-item-padding-x);
+  font-family: var(--ds-font-family-mono);
+  font-size: var(--ds-text-micro-meta-font-size);
+  letter-spacing: var(--ds-text-micro-meta-letter-spacing);
+  text-transform: uppercase;
+  color: var(--ds-color-text-secondary);
+}
+
+.lastEditedLabel {
+  font-family: var(--ds-font-family-mono);
+  font-size: var(--ds-text-section-header-font-size);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ds-color-text-secondary);
+}

--- a/packages/ds/src/stories/helpers/pageChrome.tsx
+++ b/packages/ds/src/stories/helpers/pageChrome.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from 'react';
+import { Badge } from '../../components/Badge';
+import { StatusDot, type StatusDotProps } from '../../components/StatusDot';
+import styles from './pageChrome.module.css';
+
+export interface SidebarWorkspaceHeaderProps {
+  projectLabel: string;
+  version: string;
+  status: { variant: StatusDotProps['variant']; label: string };
+}
+
+export function SidebarWorkspaceHeader({
+  projectLabel,
+  version,
+  status,
+}: SidebarWorkspaceHeaderProps) {
+  return (
+    <div className={styles.workspaceHeader}>
+      <span className={styles.workspaceEyebrow}>Active Workspace</span>
+      <p className={styles.workspaceTitle}>Project / {projectLabel}</p>
+      <span className={styles.workspaceStatusRow}>
+        <Badge variant="reference">{version}</Badge>
+        <StatusDot variant={status.variant} label={status.label} />
+      </span>
+    </div>
+  );
+}
+
+export interface SidebarStatusLabelProps {
+  children: ReactNode;
+}
+
+export function SidebarStatusLabel({ children }: SidebarStatusLabelProps) {
+  return <span className={styles.sidebarStatusLabel}>{children}</span>;
+}
+
+export interface LastEditedLabelProps {
+  children: ReactNode;
+}
+
+export function LastEditedLabel({ children }: LastEditedLabelProps) {
+  return <span className={styles.lastEditedLabel}>{children}</span>;
+}

--- a/packages/ds/src/stories/pages/tasks/TasksDesktop.stories.tsx
+++ b/packages/ds/src/stories/pages/tasks/TasksDesktop.stories.tsx
@@ -8,7 +8,6 @@ import { Selector } from '../../../components/Selector';
 import { NavItem } from '../../../components/NavItem';
 import { Avatar } from '../../../components/Avatar';
 import { SectionHeader } from '../../../components/SectionHeader';
-import { StatusDot } from '../../../components/StatusDot';
 import { Header } from '../../../components/Header';
 import { Breadcrumb } from '../../../components/Breadcrumb';
 import { SearchInput } from '../../../components/SearchInput';
@@ -34,6 +33,10 @@ import {
   orderByPrefixStyle,
   orderByValueStyle,
 } from '../../helpers/orderByStyles';
+import {
+  SidebarWorkspaceHeader,
+  SidebarStatusLabel,
+} from '../../helpers/pageChrome';
 import {
   type TaskItem,
   type DrawerFormState,
@@ -192,55 +195,11 @@ function TasksPageRender({
               }
               action={{ label: 'Add project', icon: 'add', onClick: () => {} }}
             />
-            <div style={{ marginTop: 'var(--ds-space-sidebar-section-gap)' }}>
-              <span
-                style={{
-                  fontFamily: 'var(--ds-text-section-header-font-family)',
-                  fontSize: 'var(--ds-text-section-header-font-size)',
-                  fontWeight: 'var(--ds-font-weight-medium)',
-                  letterSpacing: 'var(--ds-text-section-header-letter-spacing)',
-                  textTransform: 'uppercase' as const,
-                  color: 'var(--ds-color-text-secondary)',
-                }}
-              >
-                Active Workspace
-              </span>
-              <p
-                style={{
-                  margin: 'var(--ds-space-scale-sm) 0 var(--ds-space-scale-sm)',
-                  fontFamily: 'var(--ds-font-family-sans)',
-                  fontSize: 'var(--ds-text-page-title-font-size)',
-                  fontWeight: 'var(--ds-font-weight-bold)',
-                  color: 'var(--ds-color-text-primary)',
-                  lineHeight: 'var(--ds-text-page-title-line-height)',
-                }}
-              >
-                Project / {activeProject.label}
-              </p>
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 'var(--ds-space-scale-sm)',
-                }}
-              >
-                <span
-                  style={{
-                    fontFamily: 'var(--ds-font-family-mono)',
-                    fontSize: 'var(--ds-text-section-header-font-size)',
-                    color: 'var(--ds-color-text-secondary)',
-                    letterSpacing: '0.05em',
-                    padding:
-                      'var(--ds-space-badge-padding-y) var(--ds-space-badge-padding-x)',
-                    borderRadius: 'var(--ds-radius-lg)',
-                    backgroundColor: 'var(--ds-color-border-default)',
-                  }}
-                >
-                  v4.1.0-alpha
-                </span>
-                <StatusDot variant="active" label="Healthy" />
-              </span>
-            </div>
+            <SidebarWorkspaceHeader
+              projectLabel={activeProject.label}
+              version="v4.1.0-alpha"
+              status={{ variant: 'active', label: 'Healthy' }}
+            />
           </>
         }
         footer={
@@ -252,20 +211,7 @@ function TasksPageRender({
               size="sm"
             />
             <NavItem icon="help" label="Support" href="/support" size="sm" />
-            <span
-              style={{
-                display: 'block',
-                marginTop: '16px',
-                padding: '0 12px',
-                fontSize: '9px',
-                fontFamily: 'var(--ds-font-family-mono)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.2em',
-                color: 'var(--ds-color-text-secondary)',
-              }}
-            >
-              System Stable
-            </span>
+            <SidebarStatusLabel>System Stable</SidebarStatusLabel>
           </>
         }
       >

--- a/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.module.css
+++ b/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.module.css
@@ -225,3 +225,9 @@
   font-size: 11px;
   color: var(--ds-color-text-secondary);
 }
+
+.footerMeta {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-space-scale-md);
+}

--- a/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.stories.tsx
+++ b/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.stories.tsx
@@ -4,7 +4,6 @@ import { Sidebar } from '../../../components/Sidebar';
 import { Selector } from '../../../components/Selector';
 import { NavItem } from '../../../components/NavItem';
 import { SectionHeader } from '../../../components/SectionHeader';
-import { StatusDot } from '../../../components/StatusDot';
 import { Header } from '../../../components/Header';
 import { Footer } from '../../../components/Footer';
 import { Button } from '../../../components/Button';
@@ -22,6 +21,11 @@ import { ChecklistRow } from '../../../components/ChecklistRow';
 import { PropertyRow } from '../../../components/PropertyRow';
 import { TicketId } from '../../../components/TicketId';
 import { PipelineHierarchyPanel } from '../../../components/PipelineHierarchyPanel';
+import {
+  SidebarWorkspaceHeader,
+  SidebarStatusLabel,
+  LastEditedLabel,
+} from '../../helpers/pageChrome';
 import { useTicketOverviewState } from './useTicketOverviewState';
 import {
   getPerson,
@@ -120,55 +124,11 @@ function TicketOverviewRender() {
               }
               action={{ label: 'Add project', icon: 'add', onClick: () => {} }}
             />
-            <div style={{ marginTop: 'var(--ds-space-sidebar-section-gap)' }}>
-              <span
-                style={{
-                  fontFamily: 'var(--ds-text-section-header-font-family)',
-                  fontSize: 'var(--ds-text-section-header-font-size)',
-                  fontWeight: 'var(--ds-font-weight-medium)',
-                  letterSpacing: 'var(--ds-text-section-header-letter-spacing)',
-                  textTransform: 'uppercase' as const,
-                  color: 'var(--ds-color-text-secondary)',
-                }}
-              >
-                Active Workspace
-              </span>
-              <p
-                style={{
-                  margin: 'var(--ds-space-scale-sm) 0 var(--ds-space-scale-sm)',
-                  fontFamily: 'var(--ds-font-family-sans)',
-                  fontSize: 'var(--ds-text-page-title-font-size)',
-                  fontWeight: 'var(--ds-font-weight-bold)',
-                  color: 'var(--ds-color-text-primary)',
-                  lineHeight: 'var(--ds-text-page-title-line-height)',
-                }}
-              >
-                Project / {activeProject.label}
-              </p>
-              <span
-                style={{
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  gap: 'var(--ds-space-scale-sm)',
-                }}
-              >
-                <span
-                  style={{
-                    fontFamily: 'var(--ds-font-family-mono)',
-                    fontSize: 'var(--ds-text-section-header-font-size)',
-                    color: 'var(--ds-color-text-secondary)',
-                    letterSpacing: '0.05em',
-                    padding:
-                      'var(--ds-space-badge-padding-y) var(--ds-space-badge-padding-x)',
-                    borderRadius: 'var(--ds-radius-lg)',
-                    backgroundColor: 'var(--ds-color-border-default)',
-                  }}
-                >
-                  v4.1.0-alpha
-                </span>
-                <StatusDot variant="active" label="Healthy" />
-              </span>
-            </div>
+            <SidebarWorkspaceHeader
+              projectLabel={activeProject.label}
+              version="v4.1.0-alpha"
+              status={{ variant: 'active', label: 'Healthy' }}
+            />
           </>
         }
         footer={
@@ -180,20 +140,7 @@ function TicketOverviewRender() {
               size="sm"
             />
             <NavItem icon="help" label="Support" href="/support" size="sm" />
-            <span
-              style={{
-                display: 'block',
-                marginTop: '16px',
-                padding: '0 12px',
-                fontSize: '9px',
-                fontFamily: 'var(--ds-font-family-mono)',
-                textTransform: 'uppercase',
-                letterSpacing: '0.2em',
-                color: 'var(--ds-color-text-secondary)',
-              }}
-            >
-              System Stable
-            </span>
+            <SidebarStatusLabel>System Stable</SidebarStatusLabel>
           </>
         }
       >
@@ -555,25 +502,9 @@ function TicketOverviewRender() {
 
         <Footer
           left={
-            <span
-              style={{
-                display: 'inline-flex',
-                alignItems: 'center',
-                gap: 'var(--ds-space-scale-md)',
-              }}
-            >
+            <span className={styles.footerMeta}>
               <TicketId>{ticket.footer.ticketIdLabel}</TicketId>
-              <span
-                style={{
-                  fontFamily: 'var(--ds-font-family-mono)',
-                  fontSize: 'var(--ds-text-section-header-font-size)',
-                  letterSpacing: '0.05em',
-                  textTransform: 'uppercase',
-                  color: 'var(--ds-color-text-secondary)',
-                }}
-              >
-                {ticket.footer.lastEdited}
-              </span>
+              <LastEditedLabel>{ticket.footer.lastEdited}</LastEditedLabel>
             </span>
           }
         />

--- a/packages/ds/src/tokens/colors.ts
+++ b/packages/ds/src/tokens/colors.ts
@@ -94,6 +94,11 @@ export const colors = {
       text: text.secondary,
       border: border.default,
     },
+    reference: {
+      background: border.default,
+      text: text.secondary,
+      border: 'transparent',
+    },
   },
 
   nav: {


### PR DESCRIPTION
…ion pill

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to design-system stories, tokens, and CI/test tooling with no production app or auth/data paths affected.
> 
> **Overview**
> Adds a **`reference`** variant to **`Badge`** (mono chip styling and color tokens) for technical labels like version strings, and wires desktop page stories to use it instead of ad-hoc styled spans.
> 
> Introduces shared **`pageChrome`** helpers (`SidebarWorkspaceHeader`, `SidebarStatusLabel`, `LastEditedLabel`) so Tasks and Ticket Overview stories drop duplicated inline sidebar/footer markup.
> 
> **CI** gains job timeouts and **Playwright browser caching** on a11y/e2e jobs (full browser install on cache miss, system deps only on hit). **Storybook** sets `data-ds-viewport-applied` when the default viewport decorator runs, and the **a11y test runner** briefly waits for that attribute on the mobile viewport set to reduce flaky viewport timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc4379996d23da594cdee0faa7106f1da0d4c621. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->