### PR TITLE
feat(avatar): add tint prop for per-instance background color

### DIFF
--- a/packages/ds/src/components/Avatar/Avatar.module.css
+++ b/packages/ds/src/components/Avatar/Avatar.module.css
@@ -12,7 +12,10 @@
 .project {
   font-size: var(--ds-text-avatar-initial-font-size);
   font-weight: var(--ds-text-avatar-initial-font-weight);
-  background-color: var(--ds-color-avatar-background);
+  background-color: var(
+    --ds-color-avatar-tint,
+    var(--ds-color-avatar-background)
+  );
   color: var(--ds-color-avatar-text);
   border-radius: var(--ds-radius-md);
 }
@@ -20,7 +23,10 @@
 .profile {
   font-size: var(--ds-text-avatar-profile-initial-font-size);
   font-weight: var(--ds-text-avatar-profile-initial-font-weight);
-  background-color: var(--ds-color-avatar-profile-background);
+  background-color: var(
+    --ds-color-avatar-tint,
+    var(--ds-color-avatar-profile-background)
+  );
   color: var(--ds-color-avatar-profile-text);
   border: 1px solid var(--ds-color-avatar-profile-border);
   border-radius: var(--ds-radius-full);

--- a/packages/ds/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/ds/src/components/Avatar/Avatar.stories.tsx
@@ -8,6 +8,7 @@ const meta = {
   argTypes: {
     initial: { control: 'text' },
     variant: { control: 'select', options: ['project', 'profile'] },
+    tint: { control: 'color' },
     'aria-label': { control: 'text' },
   },
   args: {
@@ -36,6 +37,32 @@ export const AllVariants: Story = {
       <Avatar initial="H" aria-label="Project H" />
       <Avatar initial="AP" variant="profile" aria-label="Alejandra Paez" />
       <Avatar initial="CP" variant="profile" aria-label="Cleo Paez" />
+    </div>
+  ),
+};
+
+export const Tinted: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: 'var(--ds-space-scale-sm)' }}>
+      <Avatar
+        initial="AH"
+        variant="profile"
+        aria-label="Alex H."
+        tint="#7D9B84"
+      />
+      <Avatar
+        initial="CH"
+        variant="profile"
+        aria-label="Cleo H."
+        tint="#C38E70"
+      />
+      <Avatar
+        initial="VP"
+        variant="profile"
+        aria-label="Vader P."
+        tint="#6C89A8"
+      />
+      <Avatar initial="P" tint="#4f6f8f" aria-label="Project P" />
     </div>
   ),
 };

--- a/packages/ds/src/components/Avatar/Avatar.test.tsx
+++ b/packages/ds/src/components/Avatar/Avatar.test.tsx
@@ -36,4 +36,11 @@ describe('Avatar', () => {
     expect(screen.getByRole('img')).toHaveClass('profile');
     expect(screen.getByText('AD')).toBeInTheDocument();
   });
+
+  it('applies tint', () => {
+    render(<Avatar initial="AP" aria-label="Ale P." tint="#7D9B84" />);
+    expect(
+      screen.getByRole('img').style.getPropertyValue('--ds-color-avatar-tint'),
+    ).toBe('#7D9B84');
+  });
 });

--- a/packages/ds/src/components/Avatar/Avatar.tsx
+++ b/packages/ds/src/components/Avatar/Avatar.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type HTMLAttributes } from 'react';
+import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
 import { cn } from '../../utils/cn';
 import styles from './Avatar.module.css';
 
@@ -9,15 +9,37 @@ export interface AvatarProps extends HTMLAttributes<HTMLSpanElement> {
   initial: string;
   variant?: AvatarVariant;
   size?: AvatarSize;
+  /** Any CSS color string (hex, rgb, hsl, named). Overrides the variant's default background. */
+  tint?: string;
   'aria-label': string;
 }
 
 export const Avatar = forwardRef<HTMLSpanElement, AvatarProps>(
-  ({ initial, variant = 'project', size = 'md', className, ...rest }, ref) => {
+  (
+    {
+      initial,
+      variant = 'project',
+      size = 'md',
+      tint,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
     const classes = cn(styles.avatar, styles[variant], styles[size], className);
+    const mergedStyle: CSSProperties | undefined = tint
+      ? ({ ...style, '--ds-color-avatar-tint': tint } as CSSProperties)
+      : style;
 
     return (
-      <span ref={ref} role="img" className={classes} {...rest}>
+      <span
+        ref={ref}
+        role="img"
+        className={classes}
+        style={mergedStyle}
+        {...rest}
+      >
         {initial}
       </span>
     );

--- a/packages/ds/src/components/AvatarGroup/AvatarGroup.stories.tsx
+++ b/packages/ds/src/components/AvatarGroup/AvatarGroup.stories.tsx
@@ -52,19 +52,19 @@ export const MediumSize: Story = {
         initial="AH"
         aria-label="Alex H."
         variant="profile"
-        style={{ backgroundColor: '#7D9B84' }}
+        tint="#7D9B84"
       />
       <Avatar
         initial="CH"
         aria-label="Cleo H."
         variant="profile"
-        style={{ backgroundColor: '#C38E70' }}
+        tint="#C38E70"
       />
       <Avatar
         initial="VP"
         aria-label="Vader P."
         variant="profile"
-        style={{ backgroundColor: '#6C89A8' }}
+        tint="#6C89A8"
       />
     </AvatarGroup>
   ),

--- a/packages/ds/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/packages/ds/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -114,7 +114,7 @@ function MoreMenuContent({
             initial={projectInitial}
             variant="project"
             aria-label={projectLabel}
-            style={projectColor ? { backgroundColor: projectColor } : undefined}
+            tint={projectColor}
           />
           <span className={styles.projectLabel}>{projectLabel}</span>
           <Icon name="chevron_right" size="sm" />

--- a/packages/ds/src/components/ProjectPicker/ProjectPicker.test.tsx
+++ b/packages/ds/src/components/ProjectPicker/ProjectPicker.test.tsx
@@ -153,6 +153,8 @@ describe('ProjectPicker', () => {
       />,
     );
     const avatar = screen.getByRole('img', { name: 'Alpha' });
-    expect(avatar).toHaveStyle({ backgroundColor: '#ff0000' });
+    expect(avatar.style.getPropertyValue('--ds-color-avatar-tint')).toBe(
+      '#ff0000',
+    );
   });
 });

--- a/packages/ds/src/components/ProjectPicker/ProjectPicker.tsx
+++ b/packages/ds/src/components/ProjectPicker/ProjectPicker.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, type CSSProperties, type HTMLAttributes } from 'react';
+import { forwardRef, type HTMLAttributes } from 'react';
 import { Avatar } from '../Avatar';
 import { Icon } from '../Icon';
 import { SearchInput } from '../SearchInput';
@@ -75,9 +75,6 @@ export const ProjectPicker = forwardRef<HTMLDivElement, ProjectPickerProps>(
         <ul className={styles.list} role="listbox" aria-label="Projects">
           {filtered.map((project) => {
             const selected = project.value === value;
-            const avatarStyle: CSSProperties | undefined = project.avatarColor
-              ? { backgroundColor: project.avatarColor }
-              : undefined;
 
             return (
               <li
@@ -98,7 +95,7 @@ export const ProjectPicker = forwardRef<HTMLDivElement, ProjectPickerProps>(
                   initial={project.initial}
                   variant="project"
                   aria-label={project.label}
-                  style={avatarStyle}
+                  tint={project.avatarColor}
                 />
                 <span className={styles.label}>{project.label}</span>
                 {selected && (

--- a/packages/ds/src/components/Selector/Selector.stories.tsx
+++ b/packages/ds/src/components/Selector/Selector.stories.tsx
@@ -321,9 +321,7 @@ function AvatarOptionsRender() {
           variant="profile"
           initial={selected?.initial ?? '?'}
           aria-label={selected?.label ?? 'No assignee'}
-          style={
-            selected?.color ? { backgroundColor: selected.color } : undefined
-          }
+          tint={selected?.color}
         />
       }
       renderTriggerLabel={(opt) => opt.label}
@@ -335,7 +333,7 @@ function AvatarOptionsRender() {
             size="sm"
             initial={member.initial}
             aria-label={member.label}
-            style={{ backgroundColor: member.color }}
+            tint={member.color}
           />
         ) : null;
       }}

--- a/packages/ds/src/components/TaskDrawer/TaskDrawer.stories.tsx
+++ b/packages/ds/src/components/TaskDrawer/TaskDrawer.stories.tsx
@@ -212,11 +212,9 @@ function DefaultRender() {
                       assigneeOptions.find((m) => m.value === assignee)
                         ?.label ?? 'No assignee'
                     }
-                    style={{
-                      backgroundColor: assigneeOptions.find(
-                        (m) => m.value === assignee,
-                      )?.color,
-                    }}
+                    tint={
+                      assigneeOptions.find((m) => m.value === assignee)?.color
+                    }
                   />
                 }
                 renderTriggerLabel={(opt) => opt.label}
@@ -230,7 +228,7 @@ function DefaultRender() {
                       size="sm"
                       initial={member.initial}
                       aria-label={member.label}
-                      style={{ backgroundColor: member.color }}
+                      tint={member.color}
                     />
                   ) : null;
                 }}

--- a/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
+++ b/packages/ds/src/components/TicketTitleBlock/TicketTitleBlock.stories.tsx
@@ -81,14 +81,14 @@ export const WithAvatarGroup: Story = {
           aria-label="Jordan D."
           variant="profile"
           size="sm"
-          style={{ backgroundColor: '#6C89A8' }}
+          tint="#6C89A8"
         />
         <Avatar
           initial="AM"
           aria-label="Alex M."
           variant="profile"
           size="sm"
-          style={{ backgroundColor: '#C38E70' }}
+          tint="#C38E70"
         />
       </AvatarGroup>
     ),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Design-system presentation API only; behavior is backward-compatible when tint is omitted and changes are covered by unit tests and stories.
> 
> **Overview**
> Adds an optional **`tint`** prop on **`Avatar`** so callers can set a per-instance background color via the CSS custom property `--ds-color-avatar-tint`, with project/profile styles falling back to the existing design-token backgrounds when tint is omitted.
> 
> **`ProjectPicker`** and several Storybook examples (assignee selectors, bottom sheet project row, avatar groups) are updated to pass **`tint`** instead of inline **`backgroundColor`** styles; tests now assert the CSS variable rather than computed background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ca3a1a1987b2f4e375539b546956f8f7a13945d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->