### PR TITLE
feat(pipeline-hierarchy-panel): add inline add-stage editor with vali…

### DIFF
--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.module.css
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.module.css
@@ -234,3 +234,98 @@
   outline: var(--ds-focus-ring-width) solid transparent;
   box-shadow: var(--ds-focus-ring);
 }
+
+.editor {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-space-scale-xs);
+}
+
+.editorRow {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-scale-xs);
+}
+
+.editorMessage {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-scale-xs);
+  font-family: var(--ds-font-family-sans);
+  font-size: var(--ds-text-metadata-font-size);
+}
+
+.editorMessageError {
+  color: var(--ds-color-status-critical);
+}
+
+.editorMessageWarning {
+  color: var(--ds-color-status-high);
+}
+
+.editorSpacer {
+  flex-shrink: 0;
+  width: calc(var(--ds-icon-size-sm) + (var(--ds-space-scale-xs) * 2));
+}
+
+.editorInput {
+  flex: 1;
+  min-width: 0;
+  margin-right: var(--ds-space-scale-xs);
+  padding: var(--ds-space-scale-sm);
+  border: 1px solid var(--ds-color-border-default);
+  border-radius: var(--ds-radius-md);
+  background: transparent;
+  color: var(--ds-color-text-primary);
+  font-family: var(--ds-font-family-mono);
+  font-size: var(--ds-text-option-label-font-size);
+  outline: none;
+  transition-property: var(--ds-transition-property);
+  transition-duration: var(--ds-transition-duration);
+  transition-timing-function: var(--ds-transition-timing-function);
+}
+
+.editorInput::placeholder {
+  color: var(--ds-color-text-disabled);
+}
+
+.editorInput:focus-visible {
+  border-color: transparent;
+  box-shadow: var(--ds-focus-ring);
+}
+
+.editorAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: var(--ds-space-scale-xs);
+  border: none;
+  background: transparent;
+  color: var(--ds-color-text-secondary);
+  cursor: pointer;
+  border-radius: var(--ds-radius-sm);
+  transition-property: var(--ds-transition-property);
+  transition-duration: var(--ds-transition-duration);
+  transition-timing-function: var(--ds-transition-timing-function);
+}
+
+.editorAction:hover:not(:disabled) {
+  background-color: var(--ds-color-surface-hover);
+  color: var(--ds-color-text-primary);
+}
+
+.editorAction:focus-visible {
+  outline: var(--ds-focus-ring-width) solid transparent;
+  box-shadow: var(--ds-focus-ring);
+}
+
+.editorAction:disabled {
+  cursor: not-allowed;
+  opacity: var(--ds-effect-disabled-opacity);
+}
+
+.editorConfirm:not(:disabled) {
+  background-color: var(--ds-color-surface-hover);
+  color: var(--ds-color-text-primary);
+}

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.stories.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.stories.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
 import {
   PipelineHierarchyPanel,
+  type AddStageMessage,
   type PipelineHierarchyStage,
 } from './PipelineHierarchyPanel';
+import { toStageValue } from '../../utils/toStageValue';
 
 const meta: Meta<typeof PipelineHierarchyPanel> = {
   title: 'Components/PipelineHierarchyPanel',
@@ -36,6 +38,38 @@ const initialStages: readonly PipelineHierarchyStage[] = [
   { value: 'prod', label: 'Prod', status: 'idle' },
 ];
 
+function getAddStageMessage(
+  draft: string,
+  stages: readonly PipelineHierarchyStage[],
+): AddStageMessage | undefined {
+  const trimmed = draft.trim();
+  if (trimmed.length === 0) return undefined;
+  const draftValue = toStageValue(trimmed);
+  const exact = stages.find(
+    (stage) =>
+      stage.value === draftValue ||
+      stage.label.toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (exact) {
+    return { kind: 'error', text: `"${exact.label}" already exists` };
+  }
+  const lower = trimmed.toLowerCase();
+  const similar = stages.filter((stage) => {
+    const other = stage.label.toLowerCase();
+    return (
+      lower.length >= 2 && (other.startsWith(lower) || lower.startsWith(other))
+    );
+  });
+  if (similar.length > 0) {
+    const list = similar.map((s) => `"${s.label}"`).join(' and ');
+    return {
+      kind: 'warning',
+      text: `Similar to ${list} — still confirm?`,
+    };
+  }
+  return undefined;
+}
+
 function ControlledPanel({
   initial,
 }: {
@@ -43,22 +77,114 @@ function ControlledPanel({
 }) {
   const [stages, setStages] = useState(initial);
   const [active, setActive] = useState<string | undefined>('qa2');
-  return (
-    <PipelineHierarchyPanel
-      title="Pipeline Hierarchy"
-      reorderHint="Drag to reorder"
-      stages={stages}
-      activeValue={active}
-      onSelect={setActive}
-      onReorder={setStages}
-      addLabel="Add environment"
-      onAddStage={() => {
-        console.log('Add stage clicked');
-      }}
-    />
-  );
+  const [isAdding, setIsAdding] = useState(false);
+  const [draft, setDraft] = useState('');
+  const message = isAdding ? getAddStageMessage(draft, stages) : undefined;
+  const baseProps = {
+    title: 'Pipeline Hierarchy',
+    reorderHint: 'Drag to reorder',
+    stages,
+    activeValue: active,
+    onSelect: setActive,
+    onReorder: setStages,
+    addLabel: 'Add environment',
+    addStagePlaceholder: 'Prod-US',
+    onAddStage: () => {
+      setDraft('');
+      setIsAdding(true);
+    },
+  };
+  if (isAdding) {
+    return (
+      <PipelineHierarchyPanel
+        {...baseProps}
+        addingStage
+        addStageValue={draft}
+        addStageMessage={message}
+        onAddStageValueChange={setDraft}
+        onAddStageConfirm={(label) => {
+          if (getAddStageMessage(label, stages)?.kind === 'error') return;
+          setStages((current) => [
+            ...current,
+            { value: toStageValue(label), label, status: 'idle' },
+          ]);
+          setIsAdding(false);
+          setDraft('');
+        }}
+        onAddStageCancel={() => {
+          setIsAdding(false);
+          setDraft('');
+        }}
+      />
+    );
+  }
+  return <PipelineHierarchyPanel {...baseProps} />;
 }
 
 export const Default: Story = {
   render: () => <ControlledPanel initial={initialStages} />,
+};
+
+const staticEditorArgs = {
+  title: 'Pipeline Hierarchy',
+  reorderHint: 'Drag to reorder',
+  stages: initialStages,
+  activeValue: 'qa2',
+  addLabel: 'Add environment',
+  addStagePlaceholder: 'Prod-US',
+  addingStage: true as const,
+  onAddStageValueChange: () => {},
+  onAddStageConfirm: () => {},
+  onAddStageCancel: () => {},
+  onReorder: () => {},
+};
+
+export const AddingEnvironment: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Static view of the panel with the inline add-environment editor open. The input is keyboard-focused on open; Enter confirms, Escape cancels.',
+      },
+    },
+  },
+  args: {
+    ...staticEditorArgs,
+    addStageValue: 'Staging-EU',
+  },
+};
+
+export const AddingEnvironmentDuplicate: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Error state — the typed value matches an existing stage. The confirm button is disabled and Enter is a no-op.',
+      },
+    },
+  },
+  args: {
+    ...staticEditorArgs,
+    addStageValue: 'QA1',
+    addStageMessage: { kind: 'error', text: '"QA1" already exists' },
+  },
+};
+
+export const AddingEnvironmentSimilar: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Warning state — the typed value is similar to existing stages but not a duplicate. The confirm button stays enabled so the user can proceed if they intend to.',
+      },
+    },
+  },
+  args: {
+    ...staticEditorArgs,
+    addStageValue: 'QA3',
+    addStageMessage: {
+      kind: 'warning',
+      text: 'Similar to "QA1" and "QA2" — still confirm?',
+    },
+  },
 };

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.stories.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.stories.tsx
@@ -45,6 +45,12 @@ function getAddStageMessage(
   const trimmed = draft.trim();
   if (trimmed.length === 0) return undefined;
   const draftValue = toStageValue(trimmed);
+  if (draftValue === '') {
+    return {
+      kind: 'error',
+      text: 'Stage name must include a letter or number',
+    };
+  }
   const exact = stages.find(
     (stage) =>
       stage.value === draftValue ||
@@ -103,11 +109,14 @@ function ControlledPanel({
         addStageMessage={message}
         onAddStageValueChange={setDraft}
         onAddStageConfirm={(label) => {
-          if (getAddStageMessage(label, stages)?.kind === 'error') return;
-          setStages((current) => [
-            ...current,
-            { value: toStageValue(label), label, status: 'idle' },
-          ]);
+          setStages((current) => {
+            if (getAddStageMessage(label, current)?.kind === 'error')
+              return current;
+            return [
+              ...current,
+              { value: toStageValue(label), label, status: 'idle' },
+            ];
+          });
           setIsAdding(false);
           setDraft('');
         }}

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.test.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.test.tsx
@@ -396,4 +396,287 @@ describe('PipelineHierarchyPanel', () => {
     );
     expect(container.firstChild).toHaveClass('custom');
   });
+
+  describe('inline add stage editor', () => {
+    it('hides the editor and renders the add button when addingStage is false', () => {
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          onAddStage={() => {}}
+        />,
+      );
+      expect(
+        screen.getByRole('button', { name: 'Add environment' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('textbox', { name: 'Add environment' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the editor and hides the add button when addingStage is true', () => {
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          onAddStage={() => {}}
+          addingStage
+          addStageValue=""
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      expect(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Add environment' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('fires onAddStageValueChange when typing', () => {
+      const onAddStageValueChange = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue=""
+          onAddStageValueChange={onAddStageValueChange}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      fireEvent.change(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+        { target: { value: 'Prod-US' } },
+      );
+      expect(onAddStageValueChange).toHaveBeenCalledWith('Prod-US');
+    });
+
+    it('fires onAddStageConfirm with the trimmed value when clicking the confirm button', () => {
+      const onAddStageConfirm = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="  Prod-US  "
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={onAddStageConfirm}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+      expect(onAddStageConfirm).toHaveBeenCalledWith('Prod-US');
+    });
+
+    it('fires onAddStageConfirm with the trimmed value on Enter', () => {
+      const onAddStageConfirm = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="Prod-US"
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={onAddStageConfirm}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      fireEvent.keyDown(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+        { key: 'Enter' },
+      );
+      expect(onAddStageConfirm).toHaveBeenCalledWith('Prod-US');
+    });
+
+    it('fires onAddStageCancel when clicking the cancel button', () => {
+      const onAddStageCancel = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="Prod-US"
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={onAddStageCancel}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      expect(onAddStageCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onAddStageCancel on Escape', () => {
+      const onAddStageCancel = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="Prod-US"
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={onAddStageCancel}
+        />,
+      );
+      fireEvent.keyDown(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+        { key: 'Escape' },
+      );
+      expect(onAddStageCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('disables confirm and ignores Enter when the value is empty or whitespace', () => {
+      const onAddStageConfirm = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="   "
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={onAddStageConfirm}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      const confirm = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirm).toBeDisabled();
+      fireEvent.click(confirm);
+      fireEvent.keyDown(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+        { key: 'Enter' },
+      );
+      expect(onAddStageConfirm).not.toHaveBeenCalled();
+    });
+
+    it('renders an error message and disables confirm when addStageMessage.kind is error', () => {
+      const onAddStageConfirm = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="QA1"
+          addStageMessage={{ kind: 'error', text: '"QA1" already exists' }}
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={onAddStageConfirm}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      expect(screen.getByText('"QA1" already exists')).toBeInTheDocument();
+      const confirm = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirm).toBeDisabled();
+      fireEvent.keyDown(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+        { key: 'Enter' },
+      );
+      expect(onAddStageConfirm).not.toHaveBeenCalled();
+    });
+
+    it('renders a warning message but keeps confirm enabled when addStageMessage.kind is warning', () => {
+      const onAddStageConfirm = vi.fn();
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="QA3"
+          addStageMessage={{
+            kind: 'warning',
+            text: 'Similar to "QA1" and "QA2" — still confirm?',
+          }}
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={onAddStageConfirm}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      expect(
+        screen.getByText('Similar to "QA1" and "QA2" — still confirm?'),
+      ).toBeInTheDocument();
+      const confirm = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirm).not.toBeDisabled();
+      fireEvent.click(confirm);
+      expect(onAddStageConfirm).toHaveBeenCalledWith('QA3');
+    });
+
+    it('marks the input aria-invalid when an error message is set', () => {
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="QA1"
+          addStageMessage={{ kind: 'error', text: '"QA1" already exists' }}
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      expect(
+        screen.getByRole('textbox', { name: 'Add environment' }),
+      ).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not render a message row when addStageMessage is absent', () => {
+      render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          addingStage
+          addStageValue="Prod-US"
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={() => {}}
+        />,
+      );
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+
+    it('auto-focuses the input when the editor opens', () => {
+      const { rerender } = render(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          onAddStage={() => {}}
+        />,
+      );
+      expect(
+        screen.queryByRole('textbox', { name: 'Add environment' }),
+      ).not.toBeInTheDocument();
+
+      rerender(
+        <PipelineHierarchyPanel
+          title="Pipeline Hierarchy"
+          stages={stages}
+          addLabel="Add environment"
+          onAddStage={() => {}}
+          addingStage
+          addStageValue=""
+          onAddStageValueChange={() => {}}
+          onAddStageConfirm={() => {}}
+          onAddStageCancel={() => {}}
+        />,
+      );
+
+      const input = screen.getByRole('textbox', { name: 'Add environment' });
+      expect(input).toHaveFocus();
+    });
+  });
 });

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
@@ -252,6 +252,7 @@ function AddStageEditor({
 
   function handleKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
     if (event.key === 'Enter') {
+      if (event.nativeEvent.isComposing) return;
       event.preventDefault();
       if (canConfirm) onConfirm();
       return;

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
@@ -83,6 +83,8 @@ const statusLabel: Record<PipelineHierarchyStageStatus, string> = {
   critical: 'Failing',
 };
 
+const DEFAULT_ADD_LABEL = 'Add stage';
+
 export const PipelineHierarchyPanel = forwardRef<
   HTMLDivElement,
   PipelineHierarchyPanelProps
@@ -191,7 +193,7 @@ export const PipelineHierarchyPanel = forwardRef<
                 reorderable={reorderable}
                 value={addStageValue}
                 placeholder={addStagePlaceholder}
-                ariaLabel={addLabel ?? 'New stage'}
+                ariaLabel={addLabel ?? DEFAULT_ADD_LABEL}
                 canConfirm={canConfirmAddStage}
                 message={addStageMessage}
                 onValueChange={onAddStageValueChange}
@@ -209,7 +211,7 @@ export const PipelineHierarchyPanel = forwardRef<
                 onClick={onAddStage}
               >
                 <Icon name="add" size="sm" />
-                <span>{addLabel ?? 'Add stage'}</span>
+                <span>{addLabel ?? DEFAULT_ADD_LABEL}</span>
               </button>
             )}
           </>

--- a/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
+++ b/packages/ds/src/components/PipelineHierarchyPanel/PipelineHierarchyPanel.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, useRef, type HTMLAttributes } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  type HTMLAttributes,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
 import { Icon } from '../Icon';
 import { StatusDot } from '../StatusDot';
 import { cn } from '../../utils/cn';
@@ -17,10 +23,10 @@ export interface PipelineHierarchyStage {
   status?: PipelineHierarchyStageStatus;
 }
 
-export interface PipelineHierarchyPanelProps extends Omit<
+type PipelineHierarchyPanelBaseProps = Omit<
   HTMLAttributes<HTMLDivElement>,
   'onSelect'
-> {
+> & {
   title: string;
   stages: readonly PipelineHierarchyStage[];
   activeValue?: string;
@@ -29,7 +35,36 @@ export interface PipelineHierarchyPanelProps extends Omit<
   reorderHint?: string;
   addLabel?: string;
   onAddStage?: () => void;
-}
+  addStagePlaceholder?: string;
+};
+
+export type AddStageMessage =
+  | { kind: 'error'; text: string }
+  | { kind: 'warning'; text: string };
+
+// Consumers own validation (duplicate detection, format, allowed values, etc).
+// onAddStageConfirm receives the trimmed value, the panel only guards empty/whitespace
+// and addStageMessage.kind === 'error'.
+type AddStageEditorState =
+  | {
+      addingStage?: false;
+      addStageValue?: never;
+      onAddStageValueChange?: never;
+      onAddStageConfirm?: never;
+      onAddStageCancel?: never;
+      addStageMessage?: never;
+    }
+  | {
+      addingStage: true;
+      addStageValue: string;
+      onAddStageValueChange: (value: string) => void;
+      onAddStageConfirm: (value: string) => void;
+      onAddStageCancel: () => void;
+      addStageMessage?: AddStageMessage;
+    };
+
+export type PipelineHierarchyPanelProps = PipelineHierarchyPanelBaseProps &
+  AddStageEditorState;
 
 const statusVariant: Record<
   PipelineHierarchyStageStatus,
@@ -62,6 +97,13 @@ export const PipelineHierarchyPanel = forwardRef<
       reorderHint,
       addLabel,
       onAddStage,
+      addingStage = false,
+      addStageValue = '',
+      addStagePlaceholder,
+      onAddStageValueChange,
+      onAddStageConfirm,
+      onAddStageCancel = () => {},
+      addStageMessage,
       className,
       ...rest
     },
@@ -69,6 +111,10 @@ export const PipelineHierarchyPanel = forwardRef<
   ) => {
     const listRef = useRef<HTMLUListElement>(null);
     const reorderable = onReorder !== undefined;
+    const trimmedAddStageValue = addStageValue.trim();
+    const canConfirmAddStage =
+      trimmedAddStageValue.length > 0 && addStageMessage?.kind !== 'error';
+    const showAddRegion = onAddStage !== undefined || addingStage;
 
     const { onPointerDown, onKeyDown } = useDragReorder({
       items: stages,
@@ -137,17 +183,35 @@ export const PipelineHierarchyPanel = forwardRef<
             );
           })}
         </ul>
-        {onAddStage && (
+        {showAddRegion && (
           <>
             <div className={styles.divider} aria-hidden="true" />
-            <button
-              type="button"
-              className={styles.addButton}
-              onClick={onAddStage}
-            >
-              <Icon name="add" size="sm" />
-              <span>{addLabel ?? 'Add stage'}</span>
-            </button>
+            {addingStage ? (
+              <AddStageEditor
+                reorderable={reorderable}
+                value={addStageValue}
+                placeholder={addStagePlaceholder}
+                ariaLabel={addLabel ?? 'New stage'}
+                canConfirm={canConfirmAddStage}
+                message={addStageMessage}
+                onValueChange={onAddStageValueChange}
+                onConfirm={() => {
+                  if (canConfirmAddStage) {
+                    onAddStageConfirm?.(trimmedAddStageValue);
+                  }
+                }}
+                onCancel={onAddStageCancel}
+              />
+            ) : (
+              <button
+                type="button"
+                className={styles.addButton}
+                onClick={onAddStage}
+              >
+                <Icon name="add" size="sm" />
+                <span>{addLabel ?? 'Add stage'}</span>
+              </button>
+            )}
           </>
         )}
       </div>
@@ -156,6 +220,104 @@ export const PipelineHierarchyPanel = forwardRef<
 );
 
 PipelineHierarchyPanel.displayName = 'PipelineHierarchyPanel';
+
+function AddStageEditor({
+  reorderable,
+  value,
+  placeholder,
+  ariaLabel,
+  canConfirm,
+  message,
+  onValueChange,
+  onConfirm,
+  onCancel,
+}: {
+  reorderable: boolean;
+  value: string;
+  placeholder?: string;
+  ariaLabel: string;
+  canConfirm: boolean;
+  message?: AddStageMessage;
+  onValueChange?: (value: string) => void;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (canConfirm) onConfirm();
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      onCancel();
+    }
+  }
+
+  return (
+    <div className={styles.editor}>
+      <div className={styles.editorRow}>
+        {reorderable && (
+          <span className={styles.editorSpacer} aria-hidden="true" />
+        )}
+        <input
+          ref={inputRef}
+          type="text"
+          className={styles.editorInput}
+          value={value}
+          placeholder={placeholder}
+          aria-label={ariaLabel}
+          aria-invalid={message?.kind === 'error' || undefined}
+          onChange={(event) => onValueChange?.(event.currentTarget.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          type="button"
+          className={styles.editorAction}
+          aria-label="Cancel"
+          onClick={onCancel}
+        >
+          <Icon name="close" size="sm" />
+        </button>
+        <button
+          type="button"
+          className={cn(styles.editorAction, styles.editorConfirm)}
+          aria-label="Confirm"
+          disabled={!canConfirm}
+          onClick={onConfirm}
+        >
+          <Icon name="check" size="sm" />
+        </button>
+      </div>
+      {message && (
+        <div
+          className={cn(
+            styles.editorMessage,
+            message.kind === 'error'
+              ? styles.editorMessageError
+              : styles.editorMessageWarning,
+          )}
+          role={message.kind === 'error' ? 'alert' : 'status'}
+        >
+          {reorderable && (
+            <span className={styles.editorSpacer} aria-hidden="true" />
+          )}
+          <Icon
+            name={message.kind === 'error' ? 'cancel' : 'warning'}
+            size="sm"
+          />
+          <span>{message.text}</span>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function RowContents({
   stage,

--- a/packages/ds/src/components/PipelineHierarchyPanel/index.ts
+++ b/packages/ds/src/components/PipelineHierarchyPanel/index.ts
@@ -1,5 +1,6 @@
 export {
   PipelineHierarchyPanel,
+  type AddStageMessage,
   type PipelineHierarchyPanelProps,
   type PipelineHierarchyStage,
   type PipelineHierarchyStageStatus,

--- a/packages/ds/src/icons/iconRegistry.ts
+++ b/packages/ds/src/icons/iconRegistry.ts
@@ -31,6 +31,7 @@ import { SignalCellularAltIcon } from './signalCellularAlt';
 import { TagIcon } from './tag';
 import { TaskAltIcon } from './taskAlt';
 import { UnfoldMoreIcon } from './unfoldMore';
+import { WarningIcon } from './warning';
 
 export const iconRegistry = {
   add: AddIcon,
@@ -65,6 +66,7 @@ export const iconRegistry = {
   tag: TagIcon,
   task_alt: TaskAltIcon,
   unfold_more: UnfoldMoreIcon,
+  warning: WarningIcon,
 } as const satisfies Record<string, ComponentType<SVGProps<SVGSVGElement>>>;
 
 export type IconName = keyof typeof iconRegistry;

--- a/packages/ds/src/icons/index.ts
+++ b/packages/ds/src/icons/index.ts
@@ -31,3 +31,4 @@ export { SignalCellularAltIcon } from './signalCellularAlt';
 export { TagIcon } from './tag';
 export { TaskAltIcon } from './taskAlt';
 export { UnfoldMoreIcon } from './unfoldMore';
+export { WarningIcon } from './warning';

--- a/packages/ds/src/icons/warning.tsx
+++ b/packages/ds/src/icons/warning.tsx
@@ -1,0 +1,6 @@
+import { createIcon } from './createIcon';
+
+export const WarningIcon = createIcon(
+  'M40-120 480-880l440 760H40Zm138-80h604L480-720 178-200Zm302-40q17 0 28.5-11.5T520-280q0-17-11.5-28.5T480-320q-17 0-28.5 11.5T440-280q0 17 11.5 28.5T480-240Zm-40-120h80v-200h-80v200Zm40-100Z',
+  'WarningIcon',
+);

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -38,6 +38,7 @@ export {
   TagIcon,
   TaskAltIcon,
   UnfoldMoreIcon,
+  WarningIcon,
   iconRegistry,
 } from './icons';
 export { Avatar, type AvatarProps } from './components/Avatar';
@@ -132,6 +133,7 @@ export {
 export { Popover, type PopoverProps } from './components/Popover';
 export {
   PipelineHierarchyPanel,
+  type AddStageMessage,
   type PipelineHierarchyPanelProps,
   type PipelineHierarchyStage,
   type PipelineHierarchyStageStatus,

--- a/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.stories.tsx
+++ b/packages/ds/src/stories/pages/ticket-overview/TicketOverviewDesktop.stories.tsx
@@ -101,6 +101,13 @@ function TicketOverviewRender() {
     confirmBranch,
     cancelBranch,
     copyBranch,
+    addingStage,
+    addStageDraft,
+    addStageMessage,
+    openAddStage,
+    setAddStageDraft,
+    confirmAddStage,
+    cancelAddStage,
   } = useTicketOverviewState();
   const activeProject = getProject(project);
   const activeAssignee = getPerson(assignee);
@@ -513,19 +520,35 @@ function TicketOverviewRender() {
               </PropertyRow>
             </div>
 
-            {pipelineOpen && (
-              <PipelineHierarchyPanel
-                id="ticket-pipeline-hierarchy"
-                title={ticket.pipeline.title}
-                stages={pipelineStages}
-                activeValue={activeStage}
-                onSelect={setActiveStage}
-                onReorder={setPipelineStages}
-                reorderHint={ticket.pipeline.reorderHint}
-                addLabel={ticket.pipeline.addLabel}
-                onAddStage={() => {}}
-              />
-            )}
+            {pipelineOpen &&
+              (() => {
+                const panelBaseProps = {
+                  id: 'ticket-pipeline-hierarchy',
+                  title: ticket.pipeline.title,
+                  stages: pipelineStages,
+                  activeValue: activeStage,
+                  onSelect: setActiveStage,
+                  onReorder: setPipelineStages,
+                  reorderHint: ticket.pipeline.reorderHint,
+                  addLabel: ticket.pipeline.addLabel,
+                  addStagePlaceholder: ticket.pipeline.addStagePlaceholder,
+                  onAddStage: openAddStage,
+                };
+                if (addingStage) {
+                  return (
+                    <PipelineHierarchyPanel
+                      {...panelBaseProps}
+                      addingStage
+                      addStageValue={addStageDraft}
+                      addStageMessage={addStageMessage}
+                      onAddStageValueChange={setAddStageDraft}
+                      onAddStageConfirm={confirmAddStage}
+                      onAddStageCancel={cancelAddStage}
+                    />
+                  );
+                }
+                return <PipelineHierarchyPanel {...panelBaseProps} />;
+              })()}
           </aside>
         </div>
 

--- a/packages/ds/src/stories/pages/ticket-overview/shared.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/shared.ts
@@ -69,6 +69,7 @@ export interface TicketMeta {
     title: string;
     reorderHint: string;
     addLabel: string;
+    addStagePlaceholder: string;
     initialActiveStage: string;
     stages: readonly PipelineHierarchyStage[];
   };
@@ -230,6 +231,7 @@ export const ticket: TicketMeta = {
     title: 'Pipeline Hierarchy',
     reorderHint: 'Drag to reorder',
     addLabel: 'Add environment',
+    addStagePlaceholder: 'Prod-US',
     initialActiveStage: 'qa2',
     stages: [
       { value: 'qa1', label: 'QA1', status: 'success' },

--- a/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
@@ -136,6 +136,7 @@ export function useTicketOverviewState(): UseTicketOverviewState {
     ? getAddStageMessage(addStageDraft, pipelineStages)
     : undefined;
   const confirmAddStage = (label: string) => {
+    if (getAddStageMessage(label, pipelineStages)?.kind === 'error') return;
     setPipelineStages((current) => {
       if (getAddStageMessage(label, current)?.kind === 'error') return current;
       return [

--- a/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
@@ -21,6 +21,12 @@ function getAddStageMessage(
   const trimmed = draft.trim();
   if (trimmed.length === 0) return undefined;
   const draftValue = toStageValue(trimmed);
+  if (draftValue === '') {
+    return {
+      kind: 'error',
+      text: 'Stage name must include a letter or number',
+    };
+  }
   const exact = stages.find(
     (stage) =>
       stage.value === draftValue ||

--- a/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
@@ -133,11 +133,13 @@ export function useTicketOverviewState(): UseTicketOverviewState {
     ? getAddStageMessage(addStageDraft, pipelineStages)
     : undefined;
   const confirmAddStage = (label: string) => {
-    if (getAddStageMessage(label, pipelineStages)?.kind === 'error') return;
-    setPipelineStages((current) => [
-      ...current,
-      { value: toStageValue(label), label, status: 'idle' },
-    ]);
+    setPipelineStages((current) => {
+      if (getAddStageMessage(label, current)?.kind === 'error') return current;
+      return [
+        ...current,
+        { value: toStageValue(label), label, status: 'idle' },
+      ];
+    });
     setAddingStage(false);
     setAddStageDraft('');
   };

--- a/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
@@ -118,7 +118,6 @@ export function useTicketOverviewState(): UseTicketOverviewState {
     ticket.pipeline.initialActiveStage,
   );
   const [pipelineOpen, setPipelineOpen] = useState(false);
-  const togglePipelineOpen = () => setPipelineOpen((current) => !current);
   const [addingStage, setAddingStage] = useState(false);
   const [addStageDraft, setAddStageDraft] = useState('');
   const openAddStage = () => {
@@ -128,6 +127,10 @@ export function useTicketOverviewState(): UseTicketOverviewState {
   const cancelAddStage = () => {
     setAddingStage(false);
     setAddStageDraft('');
+  };
+  const togglePipelineOpen = () => {
+    if (pipelineOpen) cancelAddStage();
+    setPipelineOpen((current) => !current);
   };
   const addStageMessage = addingStage
     ? getAddStageMessage(addStageDraft, pipelineStages)

--- a/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
+++ b/packages/ds/src/stories/pages/ticket-overview/useTicketOverviewState.ts
@@ -1,14 +1,50 @@
 import { useCallback, useEffect, useState } from 'react';
-import type { PipelineHierarchyStage } from '../../../components/PipelineHierarchyPanel';
+import type {
+  AddStageMessage,
+  PipelineHierarchyStage,
+} from '../../../components/PipelineHierarchyPanel';
 import {
   useSelectorGroup,
   useSelectorState,
   type UseSelectorStateReturn,
   type SelectorGroupEntry,
 } from '../../../hooks/useSelector';
+import { toStageValue } from '../../../utils/toStageValue';
 import { ticket } from './shared';
 
 const BRANCH_COPIED_FLASH_MS = 2000;
+
+function getAddStageMessage(
+  draft: string,
+  stages: readonly PipelineHierarchyStage[],
+): AddStageMessage | undefined {
+  const trimmed = draft.trim();
+  if (trimmed.length === 0) return undefined;
+  const draftValue = toStageValue(trimmed);
+  const exact = stages.find(
+    (stage) =>
+      stage.value === draftValue ||
+      stage.label.toLowerCase() === trimmed.toLowerCase(),
+  );
+  if (exact) {
+    return { kind: 'error', text: `"${exact.label}" already exists` };
+  }
+  const lower = trimmed.toLowerCase();
+  const similar = stages.filter((stage) => {
+    const other = stage.label.toLowerCase();
+    return (
+      lower.length >= 2 && (other.startsWith(lower) || lower.startsWith(other))
+    );
+  });
+  if (similar.length > 0) {
+    const list = similar.map((s) => `"${s.label}"`).join(' and ');
+    return {
+      kind: 'warning',
+      text: `Similar to ${list} — still confirm?`,
+    };
+  }
+  return undefined;
+}
 
 export interface UseTicketOverviewState {
   project: string;
@@ -45,6 +81,13 @@ export interface UseTicketOverviewState {
   confirmBranch: () => void;
   cancelBranch: () => void;
   copyBranch: () => void;
+  addingStage: boolean;
+  addStageDraft: string;
+  addStageMessage: AddStageMessage | undefined;
+  openAddStage: () => void;
+  setAddStageDraft: (value: string) => void;
+  confirmAddStage: (label: string) => void;
+  cancelAddStage: () => void;
 }
 
 export function useTicketOverviewState(): UseTicketOverviewState {
@@ -70,6 +113,28 @@ export function useTicketOverviewState(): UseTicketOverviewState {
   );
   const [pipelineOpen, setPipelineOpen] = useState(false);
   const togglePipelineOpen = () => setPipelineOpen((current) => !current);
+  const [addingStage, setAddingStage] = useState(false);
+  const [addStageDraft, setAddStageDraft] = useState('');
+  const openAddStage = () => {
+    setAddStageDraft('');
+    setAddingStage(true);
+  };
+  const cancelAddStage = () => {
+    setAddingStage(false);
+    setAddStageDraft('');
+  };
+  const addStageMessage = addingStage
+    ? getAddStageMessage(addStageDraft, pipelineStages)
+    : undefined;
+  const confirmAddStage = (label: string) => {
+    if (getAddStageMessage(label, pipelineStages)?.kind === 'error') return;
+    setPipelineStages((current) => [
+      ...current,
+      { value: toStageValue(label), label, status: 'idle' },
+    ]);
+    setAddingStage(false);
+    setAddStageDraft('');
+  };
 
   const [branch, setBranch] = useState(ticket.metadata.branchValue);
   const [branchDraft, setBranchDraft] = useState('');
@@ -152,5 +217,12 @@ export function useTicketOverviewState(): UseTicketOverviewState {
     confirmBranch,
     cancelBranch,
     copyBranch,
+    addingStage,
+    addStageDraft,
+    addStageMessage,
+    openAddStage,
+    setAddStageDraft,
+    confirmAddStage,
+    cancelAddStage,
   };
 }

--- a/packages/ds/src/utils/toStageValue.ts
+++ b/packages/ds/src/utils/toStageValue.ts
@@ -1,0 +1,7 @@
+export function toStageValue(label: string): string {
+  return label
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
…dation messages

https://github.com/user-attachments/assets/1fd74c52-1039-4ddb-a604-58dae2e873f3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Design-system UI and optional props only; validation and persistence stay in consumers, with broad test coverage and no auth or API changes.
> 
> **Overview**
> **PipelineHierarchyPanel** now supports an inline “add environment” flow: when `addingStage` is true, the footer add button is replaced by a focused text field with confirm/cancel actions, **Enter**/**Escape** handling, and optional `addStageMessage` error or warning rows (confirm blocked only for errors and empty input). New controlled props (`addStageValue`, `onAddStageValueChange`, `onAddStageConfirm`, `onAddStageCancel`, `addStagePlaceholder`) are typed as a discriminated union with `AddStageMessage` exported from the package.
> 
> Reference stories and the ticket overview page wire up consumer-side validation (duplicate slug/label, invalid slug via `toStageValue`, similar-name warnings) and append new stages on confirm. A shared **`toStageValue`** helper slugifies labels, **`warning`** is added to the icon registry, and tests cover the editor UX and a11y roles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76946f429e8182290bde5b381716c4fba9341752. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->