### PR TITLE
feat(floating-action-bar): add pill toolbar for floating actions

### DIFF
--- a/packages/ds/src/components/FloatingActionBar/FloatingActionBar.module.css
+++ b/packages/ds/src/components/FloatingActionBar/FloatingActionBar.module.css
@@ -1,0 +1,48 @@
+.positioner {
+  position: fixed;
+  bottom: var(--ds-space-floating-action-bar-bottom-offset);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--ds-z-floating-action-bar);
+  pointer-events: none;
+  max-width: calc(100% - var(--ds-space-scale-md) * 2);
+  box-sizing: border-box;
+}
+
+.bar {
+  display: inline-flex;
+  align-items: stretch;
+  height: var(--ds-space-floating-action-bar-height);
+  background-color: var(--ds-color-floating-action-bar-background);
+  border: 1px solid var(--ds-color-floating-action-bar-border);
+  border-radius: var(--ds-radius-full);
+  box-shadow: var(--ds-elevation-floating-action-bar);
+  backdrop-filter: var(--ds-effect-blur);
+  -webkit-backdrop-filter: var(--ds-effect-blur);
+  pointer-events: auto;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+/* !important: CSS Modules hash Button's class names, so we can't outrank
+   them by specificity alone. */
+.bar > button {
+  align-self: stretch;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--ds-space-button-gap);
+  padding: 0 var(--ds-space-floating-action-bar-padding-x) !important;
+  border-radius: 0 !important;
+  border: none !important;
+}
+
+.bar > button:not(:first-child) {
+  border-left: 1px solid var(--ds-color-floating-action-bar-border);
+}
+
+.bar > button:focus-visible {
+  outline: var(--ds-focus-ring-width) solid var(--ds-color-focus-ring);
+  outline-offset: calc(var(--ds-focus-ring-width) * -1);
+  box-shadow: none !important;
+}

--- a/packages/ds/src/components/FloatingActionBar/FloatingActionBar.module.css
+++ b/packages/ds/src/components/FloatingActionBar/FloatingActionBar.module.css
@@ -38,7 +38,7 @@
 }
 
 .bar > button:not(:first-child) {
-  border-left: 1px solid var(--ds-color-floating-action-bar-border);
+  border-left: 1px solid var(--ds-color-floating-action-bar-border) !important;
 }
 
 .bar > button:focus-visible {

--- a/packages/ds/src/components/FloatingActionBar/FloatingActionBar.stories.tsx
+++ b/packages/ds/src/components/FloatingActionBar/FloatingActionBar.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { desktopViewports } from '../../../.storybook/preview';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import { FloatingActionBar } from './FloatingActionBar';
+
+const meta: Meta<typeof FloatingActionBar> = {
+  title: 'Components/FloatingActionBar',
+  component: FloatingActionBar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A pill-shaped, fixed-position toolbar that floats near the bottom of the viewport. Holds short, related actions (e.g. "Create task", "Linked tasks") that need to remain reachable while the user scrolls through a long piece of content. Children are rendered horizontally with a thin divider between each pair. Designed for short label sets (1–3 actions); on viewports narrower than the bar\'s natural width the trailing actions clip.',
+      },
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof FloatingActionBar>;
+
+export const Default: Story = {
+  parameters: { viewport: { options: desktopViewports } },
+  render: () => (
+    <FloatingActionBar aria-label="Scratchpad actions">
+      <Button variant="ghost" size="sm">
+        <Icon name="add" size="sm" />
+        Create task
+      </Button>
+      <Button variant="ghost" size="sm">
+        <Icon name="link" size="sm" />
+        Linked tasks (2)
+      </Button>
+    </FloatingActionBar>
+  ),
+};
+
+export const SingleAction: Story = {
+  parameters: { viewport: { options: desktopViewports } },
+  render: () => (
+    <FloatingActionBar aria-label="Page actions">
+      <Button variant="ghost" size="sm">
+        <Icon name="add" size="sm" />
+        Create task
+      </Button>
+    </FloatingActionBar>
+  ),
+};
+
+export const ThreeActions: Story = {
+  parameters: { viewport: { options: desktopViewports } },
+  render: () => (
+    <FloatingActionBar aria-label="Scratchpad actions">
+      <Button variant="ghost" size="sm">
+        <Icon name="add" size="sm" />
+        Create task
+      </Button>
+      <Button variant="ghost" size="sm">
+        <Icon name="link" size="sm" />
+        Linked tasks (2)
+      </Button>
+      <Button variant="ghost" size="sm">
+        <Icon name="more_horiz" size="sm" />
+        More
+      </Button>
+    </FloatingActionBar>
+  ),
+};

--- a/packages/ds/src/components/FloatingActionBar/FloatingActionBar.test.tsx
+++ b/packages/ds/src/components/FloatingActionBar/FloatingActionBar.test.tsx
@@ -1,0 +1,54 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FloatingActionBar } from './FloatingActionBar';
+
+describe('FloatingActionBar', () => {
+  it('renders children inside a labelled group', () => {
+    render(
+      <FloatingActionBar aria-label="Scratchpad actions">
+        <button type="button">Create task</button>
+        <button type="button">Linked tasks (2)</button>
+      </FloatingActionBar>,
+    );
+    const group = screen.getByRole('group', {
+      name: 'Scratchpad actions',
+    });
+    expect(group).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Create task' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Linked tasks (2)' }),
+    ).toBeInTheDocument();
+  });
+
+  it('forwards ref to the group element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <FloatingActionBar ref={ref} aria-label="Actions">
+        <button type="button">A</button>
+      </FloatingActionBar>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current).toHaveAttribute('role', 'group');
+  });
+
+  it('merges custom className onto the group', () => {
+    render(
+      <FloatingActionBar className="custom" aria-label="Actions">
+        <button type="button">A</button>
+      </FloatingActionBar>,
+    );
+    expect(screen.getByRole('group')).toHaveClass('custom');
+  });
+
+  it('spreads additional HTML attributes onto the group', () => {
+    render(
+      <FloatingActionBar data-testid="bar" aria-label="Actions">
+        <button type="button">A</button>
+      </FloatingActionBar>,
+    );
+    expect(screen.getByTestId('bar')).toBeInTheDocument();
+  });
+});

--- a/packages/ds/src/components/FloatingActionBar/FloatingActionBar.tsx
+++ b/packages/ds/src/components/FloatingActionBar/FloatingActionBar.tsx
@@ -1,0 +1,27 @@
+import { forwardRef, type HTMLAttributes } from 'react';
+import { cn } from '../../utils/cn';
+import styles from './FloatingActionBar.module.css';
+
+export interface FloatingActionBarProps extends HTMLAttributes<HTMLDivElement> {
+  'aria-label': string;
+}
+
+export const FloatingActionBar = forwardRef<
+  HTMLDivElement,
+  FloatingActionBarProps
+>(({ className, children, ...rest }, ref) => {
+  return (
+    <div className={styles.positioner}>
+      <div
+        ref={ref}
+        role="group"
+        className={cn(styles.bar, className)}
+        {...rest}
+      >
+        {children}
+      </div>
+    </div>
+  );
+});
+
+FloatingActionBar.displayName = 'FloatingActionBar';

--- a/packages/ds/src/components/FloatingActionBar/index.ts
+++ b/packages/ds/src/components/FloatingActionBar/index.ts
@@ -1,0 +1,4 @@
+export {
+  FloatingActionBar,
+  type FloatingActionBarProps,
+} from './FloatingActionBar';

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -91,6 +91,10 @@ export {
 } from './components/BottomTabBar';
 export { Header, type HeaderProps } from './components/Header';
 export {
+  FloatingActionBar,
+  type FloatingActionBarProps,
+} from './components/FloatingActionBar';
+export {
   FloatingSearch,
   type FloatingSearchProps,
 } from './components/FloatingSearch';

--- a/packages/ds/src/tokens/colors.ts
+++ b/packages/ds/src/tokens/colors.ts
@@ -198,6 +198,11 @@ export const colors = {
     border: border.default,
   },
 
+  floatingActionBar: {
+    background: 'rgba(255, 255, 255, 0.9)',
+    border: border.default,
+  },
+
   overlay: {
     backdrop: 'rgba(0, 0, 0, 0.5)',
   },

--- a/packages/ds/src/tokens/elevation.ts
+++ b/packages/ds/src/tokens/elevation.ts
@@ -3,6 +3,7 @@ export const elevation = {
   nav: '0 1px 2px 0 rgba(0, 0, 0, 0.05)',
   dropdown: '0 10px 30px -10px rgba(0, 0, 0, 0.05)',
   floatingSearch: '0 25px 50px -12px rgba(0, 0, 0, 0.05)',
+  floatingActionBar: '0 25px 50px -12px rgba(0, 0, 0, 0.05)',
   drawer: '4px 0 24px rgba(0, 0, 0, 0.12)',
   fab: '0 4px 16px rgba(0, 0, 0, 0.18)',
   bottomSheet: '0 -8px 24px rgba(0, 0, 0, 0.12)',

--- a/packages/ds/src/tokens/spacing.ts
+++ b/packages/ds/src/tokens/spacing.ts
@@ -98,6 +98,11 @@ export const spacing = {
     paddingX: '16px',
     bottomOffset: '32px',
   },
+  floatingActionBar: {
+    height: '48px',
+    paddingX: '16px',
+    bottomOffset: '32px',
+  },
   iconButton: {
     smSize: '24px',
     mdSize: '32px',

--- a/packages/ds/src/tokens/zIndex.ts
+++ b/packages/ds/src/tokens/zIndex.ts
@@ -5,6 +5,7 @@ export const zIndex = {
   dropdown: '40',
   overlay: '50',
   floatingSearch: '60',
+  floatingActionBar: '60',
   modal: '70',
 } as const;
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/0f0c2689-12d0-4b05-a3db-38fa904f71e6


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New presentational DS component and tokens only; no production app wiring or security-sensitive logic in this diff.
> 
> **Overview**
> Adds a new **`FloatingActionBar`** design-system component: a fixed, bottom-centered pill toolbar for 1–3 related actions that stay visible while scrolling.
> 
> The component is a **`role="group"`** with a required **`aria-label`**, forwards ref and HTML props, and wraps children in a blurred, elevated bar with dividers between adjacent **`button`** children (including overrides so **`Button`** styles fit the segmented layout). New **color**, **spacing**, **elevation**, and **z-index** tokens mirror **`FloatingSearch`**, and the package **`index`** re-exports the component. **Storybook** stories and **Vitest** coverage cover rendering, ref, and className/attribute forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fab1562d6ed6db6d7107a56204974b01f267d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->