### PR TITLE
fix(ci): bump playwright to 1.60.0 to fix browser-install hang

### DIFF
--- a/.github/scripts/install-playwright-browser.sh
+++ b/.github/scripts/install-playwright-browser.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Download the Playwright chromium browser binaries with a per-attempt timeout
+# and retries. The download occasionally stalls after fetching the first binary;
+# without a timeout a stalled attempt silently consumes the entire job budget.
+attempts=3
+per_attempt_timeout=180
+
+for attempt in $(seq 1 "$attempts"); do
+  echo "::group::playwright install chromium (attempt ${attempt}/${attempts})"
+  if timeout "${per_attempt_timeout}" npx playwright install chromium; then
+    echo "::endgroup::"
+    exit 0
+  fi
+  status=$?
+  echo "::endgroup::"
+  if [ "${status}" -eq 124 ]; then
+    echo "Attempt ${attempt} timed out after ${per_attempt_timeout}s."
+  else
+    echo "Attempt ${attempt} failed with exit code ${status}."
+  fi
+  sleep 5
+done
+
+echo "Playwright chromium install failed after ${attempts} attempts." >&2
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,44 +32,6 @@ jobs:
   a11y:
     runs-on: ubuntu-latest
     needs: validate
-    timeout-minutes: 5
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-
-      - run: npm ci
-
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/ms-playwright
-          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
-
-      - name: Install Playwright browsers and system deps (cache miss)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps only (cache hit)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
-      - run: npm run build-storybook -w packages/ds
-
-      - name: Serve Storybook and run a11y tests
-        run: |
-          npx http-server packages/ds/storybook-static --port 6006 --silent &
-          npx wait-on http://127.0.0.1:6006 --timeout 30000
-          npm run test:a11y -w packages/ds -- --url http://127.0.0.1:6006
-
-  e2e:
-    runs-on: ubuntu-latest
-    needs: validate
     timeout-minutes: 10
 
     steps:
@@ -89,13 +51,49 @@ jobs:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
 
-      - name: Install Playwright browsers and system deps (cache miss)
-        if: steps.pw-cache.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps chromium
-
-      - name: Install Playwright system deps only (cache hit)
-        if: steps.pw-cache.outputs.cache-hit == 'true'
+      - name: Install Playwright system deps
         run: npx playwright install-deps chromium
+
+      - name: Install Playwright chromium (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: bash .github/scripts/install-playwright-browser.sh
+
+      - run: npm run build-storybook -w packages/ds
+
+      - name: Serve Storybook and run a11y tests
+        run: |
+          npx http-server packages/ds/storybook-static --port 6006 --silent &
+          npx wait-on http://127.0.0.1:6006 --timeout 30000
+          npm run test:a11y -w packages/ds -- --url http://127.0.0.1:6006
+
+  e2e:
+    runs-on: ubuntu-latest
+    needs: validate
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install Playwright system deps
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright chromium (cache miss)
+        if: steps.pw-cache.outputs.cache-hit != 'true'
+        run: bash .github/scripts/install-playwright-browser.sh
 
       - run: npm run build-storybook -w packages/ds
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2588,13 +2588,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11753,13 +11753,13 @@
       "link": true
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11772,9 +11772,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -15072,7 +15072,7 @@
         "@fontsource/ibm-plex-mono": "5.2.7",
         "@fontsource/inter": "5.2.8",
         "@laynezh/vite-plugin-lib-assets": "2.1.3",
-        "@playwright/test": "^1.59.1",
+        "@playwright/test": "^1.60.0",
         "@storybook/addon-a11y": "^10.2.0",
         "@storybook/addon-docs": "^10.3.1",
         "@storybook/react-vite": "^10.2.0",

--- a/packages/ds/package.json
+++ b/packages/ds/package.json
@@ -47,7 +47,7 @@
     "@fontsource/ibm-plex-mono": "5.2.7",
     "@fontsource/inter": "5.2.8",
     "@laynezh/vite-plugin-lib-assets": "2.1.3",
-    "@playwright/test": "^1.59.1",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-a11y": "^10.2.0",
     "@storybook/addon-docs": "^10.3.1",
     "@storybook/react-vite": "^10.2.0",


### PR DESCRIPTION
## Issue:
- The a11y and e2e CI jobs started failing a few days ago.  this Github thread explains it: https://github.com/microsoft/playwright/issues/40724

## root cause
A known Playwright regression (< 1.60.0): a yauzl unzip bug that hangs on Node 24.16+

## What this PR does
- Root cause fix: bump @playwright/test 1.59.1 → ^1.60.0 (+ lockfile)
- Defensive guard: since Playwright’s installer has stalled on us before the browser download now runs through a small script with a per-attempt timeout (180s) and 3 retries
- Gave the jobs a bit more timeout headroom (a11y 5→10 e2e 10→15)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI workflow, a small install script, and devDependency versions; no runtime application or security-sensitive logic.
> 
> **Overview**
> Fixes failing **a11y** and **e2e** CI jobs by upgrading **`@playwright/test`** from **1.59.1** to **^1.60.0** (lockfile included), addressing a known browser-install hang on newer Node.
> 
> On cache miss, Chromium is no longer installed via `playwright install --with-deps`; **system deps** always run with `install-deps`, and browsers go through **`.github/scripts/install-playwright-browser.sh`** (180s timeout, 3 retries). Job timeouts increase (**a11y** 5→10 min, **e2e** 10→15 min).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f89fdfbc578c5bd02807ca812d1628506d683964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->