### PR TITLE
test(selector): add open-state story so a11y audits the expanded drop

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Tokens in `packages/ds/src/tokens/` are the single source of truth for colors, s
 
 All components must pass `axe` checks. Use semantic HTML; reach for ARIA only when native semantics are insufficient.
 
+**Open-state stories are required.** The a11y gate only audits the DOM a story renders — it never clicks. So any component with a closed-by-default state (dropdowns, expanded selectors, dialogs, drawers, bottom sheets, popovers, tooltips, accordions) **must** ship a story that renders that state open (e.g. `Open`, `Expanded`). Render it via props/args, not a `play` function — a `play` opens it transiently and the state can close again before the audit runs. If there is no open-state story, that state is never checked and regressions slip through silently.
+
 ## Adding a new component
 
 1. Create `packages/ds/src/components/<Name>/` with:
@@ -124,8 +126,9 @@ All components must pass `axe` checks. Use semantic HTML; reach for ARIA only wh
    - `index.ts`
 2. Export from `packages/ds/src/index.ts`.
 3. Write tests using RTL queries (`getByRole`, `getByText`) — test behaviour, not implementation.
-4. Stage files and commit — Husky lints automatically.
-5. Create a changeset: `npm run changeset`.
+4. If the component has an open/expanded state, add an open-state story (see Accessibility) — this is required, not optional.
+5. Stage files and commit — Husky lints automatically.
+6. Create a changeset: `npm run changeset`.
 
 ## Releases
 

--- a/packages/ds/src/components/Selector/Selector.stories.tsx
+++ b/packages/ds/src/components/Selector/Selector.stories.tsx
@@ -79,6 +79,20 @@ export const Default: Story = {
   render: (args) => <DefaultRender options={args.options} />,
 };
 
+export const Open: Story = {
+  args: { options: projects },
+  render: (args) => (
+    <Selector
+      options={args.options}
+      value="eng-core"
+      open
+      onOpenChange={() => {}}
+      triggerPrefix={<Avatar initial="E" aria-label="Engineering Core" />}
+      aria-label="Select project"
+    />
+  ),
+};
+
 function WithActionRender({ options, action }: RenderProps) {
   const [value, setValue] = useState('eng-core');
   const { ref, open, onOpenChange } = useSelectorState();

--- a/packages/ds/src/components/Selector/Selector.test.tsx
+++ b/packages/ds/src/components/Selector/Selector.test.tsx
@@ -138,16 +138,13 @@ describe('Selector', () => {
     expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('sets aria-controls on trigger when open', () => {
-    const { rerender } = render(
-      <Selector options={options} value="a" id="test" />,
-    );
+  it('marks the trigger as a listbox popup without aria-controls', () => {
+    const { rerender } = render(<Selector options={options} value="a" />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-haspopup', 'listbox');
+    expect(button).not.toHaveAttribute('aria-controls');
+    rerender(<Selector options={options} value="a" open />);
     expect(screen.getByRole('button')).not.toHaveAttribute('aria-controls');
-    rerender(<Selector options={options} value="a" id="test" open />);
-    expect(screen.getByRole('button')).toHaveAttribute(
-      'aria-controls',
-      'test-listbox',
-    );
   });
 
   it('sets aria-label on trigger button', () => {

--- a/packages/ds/src/components/Selector/Selector.tsx
+++ b/packages/ds/src/components/Selector/Selector.tsx
@@ -1,7 +1,6 @@
 import {
   forwardRef,
   useCallback,
-  useId,
   useRef,
   type HTMLAttributes,
   type KeyboardEvent,
@@ -95,10 +94,8 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
     },
     ref,
   ) => {
-    const reactId = useId();
     const triggerRef = useRef<HTMLButtonElement>(null);
     const selected = options.find((o) => o.value === value);
-    const listboxId = `${rest.id ?? reactId}-listbox`;
     const hasIcons = options.some((o) => o.icon !== undefined);
     const hasPrefixes = options.some((o) => o.prefix !== undefined);
     const isInline = variant === 'inline';
@@ -207,7 +204,6 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
           className={cn(styles.trigger, isInline && styles.inlineTrigger)}
           aria-haspopup="listbox"
           aria-expanded={open}
-          aria-controls={open ? listboxId : undefined}
           aria-label={ariaLabel}
           onClick={() => onOpenChange?.(!open)}
           onKeyDown={handleTriggerKeyDown}
@@ -258,7 +254,6 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
               <div className={styles.emptyState}>{emptyState}</div>
             )}
             <div
-              id={listboxId}
               role="listbox"
               className={styles.options}
               aria-label={ariaLabel ?? 'Options'}


### PR DESCRIPTION
<img width="2472" height="1408" alt="Screenshot 2026-05-30 at 1 56 44 p m" src="https://github.com/user-attachments/assets/0ab6553c-bd5a-4f89-a8fb-77cf1ce96164" />

Add open-state story for Selector (and require them going forward)

While reviewing my a11y setup I noticed two inconclusive accessibility findings on the Tasks mobile page that CI had never reported. After debugigng the issue wasn’t with the test setup(problem was that we weren’t exposing that UI state to the audit)

My a11y checks (test-storybook + axe) only evaluate the DOM rendered by a story. they don’t interact with the page or click controls. Dropdowns, overlays, and similar components are closed by default and unmount their content when closed, axe never sees their contents unless a story renders them open.Selector didn’t have a story that rendered the dropdown expanded, so the findings inside it were never evaluated in CI. They only appeared in the Storybook a11y panel when the dropdown was manually opened. (like in the image of the issue)

Note: I initially tried using a play function to open the dropdown before the audit ran but that wasn’t reliable. The component closes itself on outside interaction and by the time the audit executes the dropdown has already been removed from the DOM. **As a result the test still passes** which is wrong. Rendering the component directly in its open state is the only reliable approach. (can be automated, but it is not worth it to automate this honestly.)

Changes
* Added an Open story for Selector that renders the dropdown expanded. (CI should fail i first commit)

This applies to components such as:
* Dropdowns
* Dialogs
* Drawers
* Bottom sheets
* Popovers
* Tooltips
* Accordions

**_If a component can open it should have a story that renders it open. Otherwise that state is never included in accessibility audits._**

The accessibility tooling was working correctly, we simply weren’t rendering all of the states we expected it to validate. This change makes those states visible to CI so issues can be caught automatically.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Storybook coverage plus minor Selector ARIA attribute removal; no auth, data, or broad API surface changes.
> 
> **Overview**
> **Selector** now has an **`Open`** Storybook story that renders the listbox expanded (`open` + controlled props) so CI **axe** / test-storybook audits the dropdown DOM instead of only the closed trigger.
> 
> The README documents that **open-state stories are mandatory** for closed-by-default UI (dropdowns, dialogs, drawers, etc.), rendered via props—not `play` functions—and adds that step to the new-component checklist.
> 
> **Selector** drops **`aria-controls`** and the generated listbox **`id`** (`useId` removed); unit tests now assert the trigger keeps **`aria-haspopup="listbox"`** without **`aria-controls`** when open or closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 033aa7672535eb51fe7df3565598ce7b7878bc88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->