### PR TITLE
feat(pages/tasks-mobile): bottom-sheet pickers for task properties

### DIFF
--- a/packages/ds/e2e/pages/tasks-mobile.spec.ts
+++ b/packages/ds/e2e/pages/tasks-mobile.spec.ts
@@ -206,6 +206,118 @@ test.describe('Mobile tasks — sort sheet', () => {
   });
 });
 
+test.describe('Mobile tasks — metadata picker sheets', () => {
+  test.beforeEach(async ({ page }) => {
+    await loadStory(page);
+    await page.getByRole('button', { name: 'New task' }).click();
+    await expect(page.getByRole('dialog', { name: 'New task' })).toBeVisible();
+  });
+
+  test('assignee: open sheet, select a member, value updates and sheet closes', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Assignee: Alex H.' }).click();
+
+    const sheet = page.getByRole('dialog', { name: 'Select assignee' });
+    await expect(sheet).toBeVisible();
+
+    await sheet.getByRole('option', { name: /Cleo H\./ }).click();
+
+    await expect(sheet).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Assignee: Cleo H.' }),
+    ).toBeVisible();
+  });
+
+  test('assignee: search filters the member list', async ({ page }) => {
+    await page.getByRole('button', { name: 'Assignee: Alex H.' }).click();
+    const sheet = page.getByRole('dialog', { name: 'Select assignee' });
+
+    await sheet.getByRole('searchbox', { name: 'Search members' }).fill('cleo');
+
+    await expect(sheet.getByRole('option', { name: /Cleo H\./ })).toBeVisible();
+    await expect(sheet.getByRole('option', { name: /Vader P\./ })).toHaveCount(
+      0,
+    );
+  });
+
+  test('priority: open sheet, select an option, value updates and sheet closes', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Priority: High' }).click();
+
+    const sheet = page.getByRole('dialog', { name: 'Select priority' });
+    await expect(sheet).toBeVisible();
+
+    await sheet.getByRole('option', { name: 'Critical' }).click();
+
+    await expect(sheet).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Priority: Critical' }),
+    ).toBeVisible();
+  });
+
+  test('priority: selecting returns focus to the trigger', async ({ page }) => {
+    await page.getByRole('button', { name: 'Priority: High' }).click();
+    const sheet = page.getByRole('dialog', { name: 'Select priority' });
+
+    await sheet.getByRole('option', { name: 'Low' }).click();
+
+    await expect(sheet).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: 'Priority: Low' }),
+    ).toBeFocused();
+  });
+
+  test('linked ticket: search and select updates the value', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Linked ticket: None' }).click();
+
+    const sheet = page.getByRole('dialog', { name: 'Select linked ticket' });
+    await expect(sheet).toBeVisible();
+
+    await sheet
+      .getByRole('searchbox', { name: 'Search tickets' })
+      .fill('T-104');
+    await sheet.getByRole('option', { name: /T-104/ }).click();
+
+    await expect(sheet).not.toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /Linked ticket: T-104/ }),
+    ).toBeVisible();
+  });
+
+  test('linked ticket: "Create new ticket" action closes the sheet', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Linked ticket: None' }).click();
+    const sheet = page.getByRole('dialog', { name: 'Select linked ticket' });
+    await expect(sheet).toBeVisible();
+
+    await sheet.getByRole('button', { name: 'Create new ticket' }).click();
+
+    await expect(sheet).not.toBeVisible();
+  });
+
+  test('Escape closes the picker sheet but keeps the drawer open', async ({
+    page,
+  }) => {
+    const drawer = page.getByRole('dialog', { name: 'New task' });
+
+    await page.getByRole('button', { name: 'Priority: High' }).click();
+    const sheet = page.getByRole('dialog', { name: 'Select priority' });
+    await expect(sheet).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(sheet).not.toBeVisible();
+    await expect(drawer).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(drawer).not.toBeVisible();
+  });
+});
+
 test.describe('Mobile tasks — empty state', () => {
   test('shows empty message when no tasks', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });

--- a/packages/ds/playwright.config.ts
+++ b/packages/ds/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from '@playwright/test';
 
-const baseURL = 'http://127.0.0.1:6006';
+const baseURL = process.env.E2E_BASE_URL ?? 'http://127.0.0.1:6006';
 
 export default defineConfig({
   testDir: './e2e',
@@ -19,7 +19,7 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  ...(process.env.CI
+  ...(process.env.CI || process.env.E2E_BASE_URL
     ? {}
     : {
         webServer: {

--- a/packages/ds/src/components/BottomSheet/BottomSheet.test.tsx
+++ b/packages/ds/src/components/BottomSheet/BottomSheet.test.tsx
@@ -106,6 +106,64 @@ describe('BottomSheet', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it('Escape closes only the topmost overlay when sheets are nested', () => {
+    const onCloseOuter = vi.fn();
+    const onCloseInner = vi.fn();
+    const { rerender } = render(
+      <>
+        <BottomSheet open onClose={onCloseOuter} aria-label="Outer">
+          outer
+        </BottomSheet>
+        <BottomSheet open onClose={onCloseInner} aria-label="Inner">
+          inner
+        </BottomSheet>
+      </>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onCloseInner).toHaveBeenCalledTimes(1);
+    expect(onCloseOuter).not.toHaveBeenCalled();
+
+    rerender(
+      <>
+        <BottomSheet open onClose={onCloseOuter} aria-label="Outer">
+          outer
+        </BottomSheet>
+        <BottomSheet open={false} onClose={onCloseInner} aria-label="Inner">
+          inner
+        </BottomSheet>
+      </>,
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onCloseOuter).toHaveBeenCalledTimes(1);
+    expect(onCloseInner).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape closes the visually-topmost overlay when overlays mount nested in one commit', () => {
+    const spies = { Outer: vi.fn(), Inner: vi.fn() };
+    render(
+      <BottomSheet open onClose={spies.Outer} aria-label="Outer">
+        <BottomSheet open onClose={spies.Inner} aria-label="Inner">
+          inner
+        </BottomSheet>
+      </BottomSheet>,
+    );
+
+    const backdrops = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-ds-overlay="open"]'),
+    );
+    const topLabel = backdrops[backdrops.length - 1]
+      .querySelector('[role="dialog"]')
+      ?.getAttribute('aria-label') as 'Outer' | 'Inner';
+    const lowerLabel = topLabel === 'Outer' ? 'Inner' : 'Outer';
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    expect(spies[topLabel]).toHaveBeenCalledTimes(1);
+    expect(spies[lowerLabel]).not.toHaveBeenCalled();
+  });
+
   it('does not call onClose on Escape when a nested handler prevented default', () => {
     const onClose = vi.fn();
     render(

--- a/packages/ds/src/components/Header/Header.stories.tsx
+++ b/packages/ds/src/components/Header/Header.stories.tsx
@@ -243,7 +243,6 @@ function MobileRender() {
             onClear={query ? () => setQuery('') : undefined}
             borderless
             className={searchPillStyles.searchPill}
-            style={{ fontSize: 16 }}
           />
           <button
             type="button"

--- a/packages/ds/src/components/OptionList/OptionList.module.css
+++ b/packages/ds/src/components/OptionList/OptionList.module.css
@@ -1,0 +1,141 @@
+.list {
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  padding: var(--ds-space-scale-sm) var(--ds-space-nav-item-padding-x) 0;
+  border-bottom: 1px solid var(--ds-color-border-default);
+}
+
+.header > :last-child {
+  border-bottom: none;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  padding: var(--ds-space-dropdown-inset);
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.options:empty {
+  display: none;
+}
+
+.emptyState {
+  padding: var(--ds-space-scale-md) var(--ds-space-nav-item-padding-x);
+  font-size: var(--ds-text-nav-label-sm-font-size);
+  font-family: var(--ds-text-nav-label-sm-font-family);
+  color: var(--ds-color-text-secondary);
+  text-align: center;
+}
+
+.option {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-nav-item-gap);
+  padding: var(--ds-space-dropdown-option-padding-y)
+    var(--ds-space-nav-item-padding-x);
+  border-radius: var(--ds-radius-xl);
+  cursor: pointer;
+  transition-property: var(--ds-transition-property);
+  transition-duration: var(--ds-transition-duration);
+  transition-timing-function: var(--ds-transition-timing-function);
+}
+
+.option:hover {
+  background-color: var(--ds-color-surface-hover);
+}
+
+.optionSelected {
+  background-color: var(--ds-color-sidebar-background);
+}
+
+.dot {
+  width: var(--ds-space-status-dot-size);
+  height: var(--ds-space-status-dot-size);
+  border-radius: var(--ds-radius-full);
+  flex-shrink: 0;
+}
+
+.dotActive {
+  background-color: var(--ds-color-accent-primary);
+}
+
+.dotInactive {
+  background-color: var(--ds-color-text-disabled);
+  opacity: var(--ds-effect-muted-opacity);
+}
+
+.optionIcon {
+  flex-shrink: 0;
+  color: var(--selector-icon-color, currentColor);
+}
+
+.optionPrefix {
+  flex-shrink: 0;
+  min-width: var(--ds-space-ticket-id-min-width);
+  text-align: left;
+  font-size: var(--ds-text-ticket-id-font-size);
+  font-family: var(--ds-text-ticket-id-font-family);
+  font-weight: var(--ds-font-weight-bold);
+  line-height: var(--ds-text-ticket-id-line-height);
+  color: var(--ds-color-text-secondary);
+  white-space: nowrap;
+}
+
+.optionLabel {
+  flex: 1;
+  font-size: var(--ds-text-nav-label-font-size);
+  font-family: var(--ds-text-nav-label-font-family);
+  font-weight: var(--ds-text-nav-label-font-weight);
+  line-height: var(--ds-text-nav-label-line-height);
+  color: var(--ds-color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.optionSelected .optionLabel {
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-text-primary);
+}
+
+.checkIcon {
+  flex-shrink: 0;
+  color: var(--ds-color-accent-primary);
+}
+
+.actionWrapper {
+  padding-top: var(--ds-space-scale-xs);
+  border-top: 1px solid var(--ds-color-border-default);
+}
+
+.action {
+  display: flex;
+  align-items: center;
+  gap: var(--ds-space-nav-item-gap);
+  margin: 0 var(--ds-space-dropdown-inset);
+  width: calc(100% - 2 * var(--ds-space-dropdown-inset));
+  padding: var(--ds-space-dropdown-option-padding-y)
+    var(--ds-space-nav-item-padding-x);
+  background: none;
+  border: none;
+  border-radius: var(--ds-radius-xl);
+  cursor: pointer;
+  font-size: var(--ds-text-nav-label-font-size);
+  font-family: var(--ds-text-nav-label-font-family);
+  font-weight: var(--ds-font-weight-medium);
+  line-height: var(--ds-text-nav-label-line-height);
+  color: var(--ds-color-text-secondary);
+  transition-property: var(--ds-transition-property);
+  transition-duration: var(--ds-transition-duration);
+  transition-timing-function: var(--ds-transition-timing-function);
+}
+
+.action:hover {
+  background-color: var(--ds-color-surface-hover);
+  color: var(--ds-color-text-primary);
+}

--- a/packages/ds/src/components/OptionList/OptionList.stories.tsx
+++ b/packages/ds/src/components/OptionList/OptionList.stories.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { OptionList } from './OptionList';
+import { SearchInput } from '../SearchInput';
+
+const people = [
+  { value: 'alex', label: 'Alex H.' },
+  { value: 'cleo', label: 'Cleo H.' },
+  { value: 'vader', label: 'Vader P.' },
+];
+
+const priorities = [
+  {
+    value: 'critical',
+    label: 'Critical',
+    icon: 'flag' as const,
+    iconColor: 'var(--ds-color-status-critical)',
+  },
+  {
+    value: 'high',
+    label: 'High',
+    icon: 'flag' as const,
+    iconColor: 'var(--ds-color-status-high)',
+  },
+  {
+    value: 'medium',
+    label: 'Medium',
+    icon: 'flag' as const,
+    iconColor: 'var(--ds-color-status-medium)',
+  },
+  {
+    value: 'low',
+    label: 'Low',
+    icon: 'flag' as const,
+    iconColor: 'var(--ds-color-status-low)',
+  },
+];
+
+const tickets = [
+  { value: 'T-42', label: 'Implement dynamic edge-caching', prefix: 'T-42' },
+  { value: 'T-104', label: 'Unit tests for cache logic', prefix: 'T-104' },
+  { value: 'T-105', label: 'Update staging config', prefix: 'T-105' },
+];
+
+const meta: Meta<typeof OptionList> = {
+  title: 'Components/OptionList',
+  component: OptionList,
+  parameters: { layout: 'centered' },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          width: 320,
+          padding: 'var(--ds-space-scale-xs) 0',
+          border: '1px solid var(--ds-color-border-default)',
+          borderRadius: 'var(--ds-radius-2xl)',
+          background: 'var(--ds-color-surface-primary)',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof OptionList>;
+
+function DefaultRender() {
+  const [value, setValue] = useState('alex');
+  return (
+    <OptionList
+      options={people}
+      value={value}
+      onSelect={setValue}
+      aria-label="Members"
+    />
+  );
+}
+
+function IconOptionsRender() {
+  const [value, setValue] = useState('high');
+  return (
+    <OptionList
+      options={priorities}
+      value={value}
+      onSelect={setValue}
+      aria-label="Priority"
+    />
+  );
+}
+
+function WithSearchHeaderRender() {
+  const [value, setValue] = useState('alex');
+  const [query, setQuery] = useState('');
+  const filtered = query
+    ? people.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
+    : people;
+  return (
+    <OptionList
+      options={filtered}
+      value={value}
+      onSelect={setValue}
+      header={
+        <SearchInput
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search members..."
+          aria-label="Search members"
+          size="sm"
+        />
+      }
+      emptyState="No members found"
+      aria-label="Members"
+    />
+  );
+}
+
+function WithActionRender() {
+  const [value, setValue] = useState('T-42');
+  return (
+    <OptionList
+      options={tickets}
+      value={value}
+      onSelect={setValue}
+      action={{ label: 'Create new ticket', icon: 'add', onClick: () => {} }}
+      aria-label="Linked ticket"
+    />
+  );
+}
+
+export const Default: Story = { render: () => <DefaultRender /> };
+export const IconOptions: Story = { render: () => <IconOptionsRender /> };
+export const WithSearchHeader: Story = {
+  render: () => <WithSearchHeaderRender />,
+};
+export const WithAction: Story = { render: () => <WithActionRender /> };
+
+export const EmptyState: Story = {
+  render: () => (
+    <OptionList
+      options={[]}
+      onSelect={() => {}}
+      emptyState="No results found"
+      aria-label="Results"
+    />
+  ),
+};

--- a/packages/ds/src/components/OptionList/OptionList.test.tsx
+++ b/packages/ds/src/components/OptionList/OptionList.test.tsx
@@ -1,0 +1,244 @@
+import { createRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { OptionList } from './OptionList';
+
+const options = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+  { value: 'c', label: 'Gamma' },
+];
+
+describe('OptionList', () => {
+  it('renders all options inside a listbox', () => {
+    render(
+      <OptionList
+        options={options}
+        value="a"
+        onSelect={vi.fn()}
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    const opts = screen.getAllByRole('option');
+    expect(opts).toHaveLength(3);
+    expect(opts[0]).toHaveTextContent('Alpha');
+  });
+
+  it('marks the selected option with aria-selected', () => {
+    render(
+      <OptionList
+        options={options}
+        value="b"
+        onSelect={vi.fn()}
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByRole('option', { selected: true })).toHaveTextContent(
+      'Beta',
+    );
+  });
+
+  it('labels the listbox with aria-label', () => {
+    render(
+      <OptionList options={options} onSelect={vi.fn()} aria-label="Members" />,
+    );
+    expect(
+      screen.getByRole('listbox', { name: 'Members' }),
+    ).toBeInTheDocument();
+  });
+
+  it('applies listboxId to the listbox', () => {
+    render(
+      <OptionList
+        options={options}
+        onSelect={vi.fn()}
+        listboxId="picker-list"
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByRole('listbox')).toHaveAttribute('id', 'picker-list');
+  });
+
+  it('calls onSelect on option click', async () => {
+    const onSelect = vi.fn();
+    render(
+      <OptionList
+        options={options}
+        value="a"
+        onSelect={onSelect}
+        aria-label="Options"
+      />,
+    );
+    await userEvent.click(screen.getByText('Beta'));
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('calls onSelect on Enter', async () => {
+    const onSelect = vi.fn();
+    render(
+      <OptionList
+        options={options}
+        value="a"
+        onSelect={onSelect}
+        aria-label="Options"
+      />,
+    );
+    screen.getAllByRole('option')[1].focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+
+  it('calls onSelect on Space', async () => {
+    const onSelect = vi.fn();
+    render(
+      <OptionList
+        options={options}
+        value="a"
+        onSelect={onSelect}
+        aria-label="Options"
+      />,
+    );
+    screen.getAllByRole('option')[2].focus();
+    await userEvent.keyboard('{ }');
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('moves focus to next option on ArrowDown', async () => {
+    render(
+      <OptionList options={options} onSelect={vi.fn()} aria-label="Options" />,
+    );
+    const opts = screen.getAllByRole('option');
+    opts[0].focus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(opts[1]).toHaveFocus();
+  });
+
+  it('moves focus to previous option on ArrowUp', async () => {
+    render(
+      <OptionList options={options} onSelect={vi.fn()} aria-label="Options" />,
+    );
+    const opts = screen.getAllByRole('option');
+    opts[1].focus();
+    await userEvent.keyboard('{ArrowUp}');
+    expect(opts[0]).toHaveFocus();
+  });
+
+  it('renders header content above the options', () => {
+    render(
+      <OptionList
+        options={options}
+        onSelect={vi.fn()}
+        header={<input placeholder="Search..." />}
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('renders empty state when there are no options', () => {
+    render(
+      <OptionList
+        options={[]}
+        onSelect={vi.fn()}
+        emptyState="No results"
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByText('No results')).toBeInTheDocument();
+  });
+
+  it('does not render empty state when options exist', () => {
+    render(
+      <OptionList
+        options={options}
+        onSelect={vi.fn()}
+        emptyState="No results"
+        aria-label="Options"
+      />,
+    );
+    expect(screen.queryByText('No results')).not.toBeInTheDocument();
+  });
+
+  it('renders and triggers the action button', async () => {
+    const onClick = vi.fn();
+    render(
+      <OptionList
+        options={options}
+        onSelect={vi.fn()}
+        action={{ label: 'Create new', icon: 'add', onClick }}
+        aria-label="Options"
+      />,
+    );
+    await userEvent.click(screen.getByText('Create new'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses a custom option indicator when provided', () => {
+    render(
+      <OptionList
+        options={options}
+        value="a"
+        onSelect={vi.fn()}
+        renderOptionIndicator={(opt) => (
+          <span data-testid={`ind-${opt.value}`} />
+        )}
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByTestId('ind-a')).toBeInTheDocument();
+    expect(screen.getByTestId('ind-c')).toBeInTheDocument();
+  });
+
+  it('renders icon indicator with iconColor as a CSS custom property', () => {
+    const iconOptions = [
+      { value: 'high', label: 'High', icon: 'flag' as const, iconColor: 'red' },
+    ];
+    const { container } = render(
+      <OptionList
+        options={iconOptions}
+        value="high"
+        onSelect={vi.fn()}
+        aria-label="Options"
+      />,
+    );
+    const colored = Array.from(
+      container.querySelectorAll('[aria-hidden="true"]'),
+    ).find(
+      (el) =>
+        (el as HTMLElement).style.getPropertyValue('--selector-icon-color') ===
+        'red',
+    );
+    expect(colored).toBeTruthy();
+  });
+
+  it('renders prefix indicator instead of a dot', () => {
+    const prefixOptions = [
+      { value: 'T-42', label: 'Edge caching', prefix: 'T-42' },
+    ];
+    const { container } = render(
+      <OptionList
+        options={prefixOptions}
+        value="T-42"
+        onSelect={vi.fn()}
+        aria-label="Options"
+      />,
+    );
+    expect(screen.getByText('T-42')).toBeInTheDocument();
+    expect(container.querySelectorAll('[class*="dot"]')).toHaveLength(0);
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <OptionList
+        ref={ref}
+        options={options}
+        onSelect={vi.fn()}
+        aria-label="Options"
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+});

--- a/packages/ds/src/components/OptionList/OptionList.tsx
+++ b/packages/ds/src/components/OptionList/OptionList.tsx
@@ -1,0 +1,197 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type ReactNode,
+} from 'react';
+import { Icon } from '../Icon';
+import type { IconName } from '../../icons';
+import { cn } from '../../utils/cn';
+import styles from './OptionList.module.css';
+
+type OptionBase = Readonly<{ value: string; label: string }>;
+type DotOption = OptionBase & {
+  icon?: never;
+  iconColor?: never;
+  prefix?: never;
+};
+type IconOption = OptionBase & {
+  icon: IconName;
+  iconColor?: string;
+  prefix?: never;
+};
+type PrefixOption = OptionBase & {
+  prefix: string;
+  icon?: never;
+  iconColor?: never;
+};
+
+export type OptionListOption = DotOption | IconOption | PrefixOption;
+
+export type OptionListAction = Readonly<{
+  label: string;
+  icon: IconName;
+  onClick: () => void;
+}>;
+
+export type OptionListOptions =
+  | readonly DotOption[]
+  | readonly IconOption[]
+  | readonly PrefixOption[];
+
+export interface OptionListProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'onSelect' | 'aria-label'
+> {
+  options: OptionListOptions;
+  value?: string;
+  onSelect: (value: string) => void;
+  header?: ReactNode;
+  emptyState?: ReactNode;
+  action?: OptionListAction;
+  listboxId?: string;
+  renderOptionIndicator?: (option: OptionListOption) => ReactNode;
+  'aria-label': string;
+}
+
+function defaultOptionIndicator(option: OptionListOption, value?: string) {
+  if (option.icon) {
+    return (
+      <Icon
+        name={option.icon}
+        size="sm"
+        className={styles.optionIcon}
+        style={
+          option.iconColor
+            ? ({
+                '--selector-icon-color': option.iconColor,
+              } as CSSProperties)
+            : undefined
+        }
+      />
+    );
+  }
+  if (option.prefix) {
+    return <span className={styles.optionPrefix}>{option.prefix}</span>;
+  }
+  const isSelected = option.value === value;
+  return (
+    <span
+      className={cn(
+        styles.dot,
+        isSelected ? styles.dotActive : styles.dotInactive,
+      )}
+    />
+  );
+}
+
+function focusSibling(current: EventTarget, direction: 'next' | 'prev') {
+  if (!(current instanceof HTMLElement)) return;
+  const sibling =
+    direction === 'next'
+      ? current.nextElementSibling
+      : current.previousElementSibling;
+  if (sibling instanceof HTMLElement) {
+    sibling.focus();
+  }
+}
+
+export const OptionList = forwardRef<HTMLDivElement, OptionListProps>(
+  (
+    {
+      options,
+      value,
+      onSelect,
+      header,
+      emptyState,
+      action,
+      listboxId,
+      renderOptionIndicator,
+      className,
+      'aria-label': ariaLabel,
+      ...rest
+    },
+    ref,
+  ) => {
+    const renderIndicator =
+      renderOptionIndicator ??
+      ((option: OptionListOption) => defaultOptionIndicator(option, value));
+
+    const handleOptionKeyDown =
+      (optionValue: string) => (e: KeyboardEvent<HTMLDivElement>) => {
+        switch (e.key) {
+          case 'Enter':
+          case ' ':
+            e.preventDefault();
+            onSelect(optionValue);
+            break;
+          case 'ArrowDown':
+            e.preventDefault();
+            focusSibling(e.target, 'next');
+            break;
+          case 'ArrowUp':
+            e.preventDefault();
+            focusSibling(e.target, 'prev');
+            break;
+        }
+      };
+
+    return (
+      <div ref={ref} className={cn(styles.list, className)} {...rest}>
+        {header && <div className={styles.header}>{header}</div>}
+        {options.length === 0 && emptyState && (
+          <div className={styles.emptyState}>{emptyState}</div>
+        )}
+        <div
+          id={listboxId}
+          role="listbox"
+          className={styles.options}
+          aria-label={ariaLabel}
+        >
+          {options.map((option) => {
+            const isSelected = option.value === value;
+            return (
+              <div
+                key={option.value}
+                role="option"
+                tabIndex={0}
+                aria-selected={isSelected}
+                className={cn(
+                  styles.option,
+                  isSelected && styles.optionSelected,
+                )}
+                onClick={() => onSelect(option.value)}
+                onKeyDown={handleOptionKeyDown(option.value)}
+              >
+                {renderIndicator(option)}
+                <span className={styles.optionLabel}>{option.label}</span>
+                {isSelected && (
+                  <Icon
+                    name="check_circle"
+                    size="sm"
+                    className={styles.checkIcon}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+        {action && (
+          <div className={styles.actionWrapper}>
+            <button
+              type="button"
+              className={styles.action}
+              onClick={action.onClick}
+            >
+              <Icon name={action.icon} size="sm" />
+              <span>{action.label}</span>
+            </button>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+OptionList.displayName = 'OptionList';

--- a/packages/ds/src/components/OptionList/index.ts
+++ b/packages/ds/src/components/OptionList/index.ts
@@ -1,0 +1,7 @@
+export {
+  OptionList,
+  type OptionListProps,
+  type OptionListOption,
+  type OptionListAction,
+  type OptionListOptions,
+} from './OptionList';

--- a/packages/ds/src/components/ProjectPicker/ProjectPicker.tsx
+++ b/packages/ds/src/components/ProjectPicker/ProjectPicker.tsx
@@ -66,8 +66,6 @@ export const ProjectPicker = forwardRef<HTMLDivElement, ProjectPickerProps>(
               value={query}
               onChange={(e) => onQueryChange(e.target.value)}
               onClear={query ? () => onQueryChange('') : undefined}
-              // 16px prevents iOS from zooming on focus
-              style={{ fontSize: 16 }}
             />
           </div>
         </div>

--- a/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.test.tsx
@@ -53,6 +53,22 @@ describe('PropertyRow', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('uses valueLabel as the accessible name of the interactive value', () => {
+    render(
+      <PropertyRow
+        icon="person"
+        label="Assignee"
+        onClick={vi.fn()}
+        valueLabel="Assignee: Alex D."
+      >
+        Alex D.
+      </PropertyRow>,
+    );
+    expect(
+      screen.getByRole('button', { name: 'Assignee: Alex D.' }),
+    ).toBeInTheDocument();
+  });
+
   it('forwards ref', () => {
     const ref = createRef<HTMLDivElement>();
     render(

--- a/packages/ds/src/components/PropertyRow/PropertyRow.tsx
+++ b/packages/ds/src/components/PropertyRow/PropertyRow.tsx
@@ -8,10 +8,11 @@ export interface PropertyRowProps extends HTMLAttributes<HTMLDivElement> {
   icon?: IconName;
   label: string;
   onClick?: () => void;
+  valueLabel?: string;
 }
 
 export const PropertyRow = forwardRef<HTMLDivElement, PropertyRowProps>(
-  ({ icon, label, onClick, className, children, ...rest }, ref) => {
+  ({ icon, label, onClick, valueLabel, className, children, ...rest }, ref) => {
     const interactive = onClick !== undefined;
     const Value = interactive ? 'button' : 'div';
 
@@ -25,6 +26,7 @@ export const PropertyRow = forwardRef<HTMLDivElement, PropertyRowProps>(
           type={interactive ? 'button' : undefined}
           className={cn(styles.value, interactive && styles.interactive)}
           onClick={onClick}
+          aria-label={interactive ? valueLabel : undefined}
         >
           {children}
         </Value>

--- a/packages/ds/src/components/SearchInput/SearchInput.module.css
+++ b/packages/ds/src/components/SearchInput/SearchInput.module.css
@@ -112,3 +112,12 @@
   line-height: 1;
   white-space: nowrap;
 }
+
+/* iOS Safari auto-zooms on focus when an input is below 16px;
+   hold search inputs at 16px on touch devices to prevent it. */
+@media (pointer: coarse) {
+  .md .input,
+  .sm .input {
+    font-size: 16px;
+  }
+}

--- a/packages/ds/src/components/Selector/Selector.module.css
+++ b/packages/ds/src/components/Selector/Selector.module.css
@@ -25,6 +25,11 @@
   align-items: center;
 }
 
+.triggerIcon {
+  flex-shrink: 0;
+  color: var(--selector-icon-color, currentColor);
+}
+
 .label {
   flex: 1;
   text-align: left;
@@ -78,143 +83,6 @@
   left: auto;
   right: 0;
   width: var(--ds-space-dropdown-end-width);
-}
-
-.header {
-  padding: var(--ds-space-scale-sm) var(--ds-space-nav-item-padding-x) 0;
-  border-bottom: 1px solid var(--ds-color-border-default);
-}
-
-.header > :last-child {
-  border-bottom: none;
-}
-
-.options {
-  display: flex;
-  flex-direction: column;
-  padding: var(--ds-space-dropdown-inset);
-  max-height: 240px;
-  overflow-y: auto;
-}
-
-.options:empty {
-  display: none;
-}
-
-.emptyState {
-  padding: var(--ds-space-scale-md) var(--ds-space-nav-item-padding-x);
-  font-size: var(--ds-text-nav-label-sm-font-size);
-  font-family: var(--ds-text-nav-label-sm-font-family);
-  color: var(--ds-color-text-secondary);
-  text-align: center;
-}
-
-.option {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-space-nav-item-gap);
-  padding: var(--ds-space-dropdown-option-padding-y)
-    var(--ds-space-nav-item-padding-x);
-  border-radius: var(--ds-radius-xl);
-  cursor: pointer;
-  transition-property: var(--ds-transition-property);
-  transition-duration: var(--ds-transition-duration);
-  transition-timing-function: var(--ds-transition-timing-function);
-}
-
-.option:hover {
-  background-color: var(--ds-color-surface-hover);
-}
-
-.optionSelected {
-  background-color: var(--ds-color-sidebar-background);
-}
-
-.dot {
-  width: var(--ds-space-status-dot-size);
-  height: var(--ds-space-status-dot-size);
-  border-radius: var(--ds-radius-full);
-  flex-shrink: 0;
-}
-
-.dotActive {
-  background-color: var(--ds-color-accent-primary);
-}
-
-.optionIcon {
-  flex-shrink: 0;
-  color: var(--selector-icon-color, currentColor);
-}
-
-.optionPrefix {
-  flex-shrink: 0;
-  min-width: var(--ds-space-ticket-id-min-width);
-  text-align: left;
-  font-size: var(--ds-text-ticket-id-font-size);
-  font-family: var(--ds-text-ticket-id-font-family);
-  font-weight: var(--ds-font-weight-bold);
-  line-height: var(--ds-text-ticket-id-line-height);
-  color: var(--ds-color-text-secondary);
-  white-space: nowrap;
-}
-
-.dotInactive {
-  background-color: var(--ds-color-text-disabled);
-  opacity: var(--ds-effect-muted-opacity);
-}
-
-.optionLabel {
-  flex: 1;
-  font-size: var(--ds-text-nav-label-font-size);
-  font-family: var(--ds-text-nav-label-font-family);
-  font-weight: var(--ds-text-nav-label-font-weight);
-  line-height: var(--ds-text-nav-label-line-height);
-  color: var(--ds-color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.optionSelected .optionLabel {
-  font-weight: var(--ds-font-weight-semibold);
-  color: var(--ds-color-text-primary);
-}
-
-.checkIcon {
-  flex-shrink: 0;
-  color: var(--ds-color-accent-primary);
-}
-
-.actionWrapper {
-  padding-top: var(--ds-space-scale-xs);
-  border-top: 1px solid var(--ds-color-border-default);
-}
-
-.action {
-  display: flex;
-  align-items: center;
-  gap: var(--ds-space-nav-item-gap);
-  margin: 0 var(--ds-space-dropdown-inset);
-  width: calc(100% - 2 * var(--ds-space-dropdown-inset));
-  padding: var(--ds-space-dropdown-option-padding-y)
-    var(--ds-space-nav-item-padding-x);
-  background: none;
-  border: none;
-  border-radius: var(--ds-radius-xl);
-  cursor: pointer;
-  font-size: var(--ds-text-nav-label-font-size);
-  font-family: var(--ds-text-nav-label-font-family);
-  font-weight: var(--ds-font-weight-medium);
-  line-height: var(--ds-text-nav-label-line-height);
-  color: var(--ds-color-text-secondary);
-  transition-property: var(--ds-transition-property);
-  transition-duration: var(--ds-transition-duration);
-  transition-timing-function: var(--ds-transition-timing-function);
-}
-
-.action:hover {
-  background-color: var(--ds-color-surface-hover);
-  color: var(--ds-color-text-primary);
 }
 
 @media (max-width: 480px) {

--- a/packages/ds/src/components/Selector/Selector.tsx
+++ b/packages/ds/src/components/Selector/Selector.tsx
@@ -7,41 +7,18 @@ import {
   type ReactNode,
 } from 'react';
 import { Icon } from '../Icon';
-import type { IconName } from '../../icons';
+import {
+  OptionList,
+  type OptionListOption as SelectorOption,
+  type OptionListAction as SelectorAction,
+  type OptionListOptions as SelectorOptions,
+} from '../OptionList';
 import { cn } from '../../utils/cn';
 import styles from './Selector.module.css';
 
-type OptionBase = Readonly<{ value: string; label: string }>;
-type DotOption = OptionBase & {
-  icon?: never;
-  iconColor?: never;
-  prefix?: never;
-};
-type IconOption = OptionBase & {
-  icon: IconName;
-  iconColor?: string;
-  prefix?: never;
-};
-type PrefixOption = OptionBase & {
-  prefix: string;
-  icon?: never;
-  iconColor?: never;
-};
-
-export type SelectorOption = DotOption | IconOption | PrefixOption;
-
-export type SelectorAction = Readonly<{
-  label: string;
-  icon: IconName;
-  onClick: () => void;
-}>;
+export type { SelectorOption, SelectorAction };
 
 type DropdownAlign = 'stretch' | 'end';
-
-type SelectorOptions =
-  | readonly DotOption[]
-  | readonly IconOption[]
-  | readonly PrefixOption[];
 
 export interface SelectorProps extends HTMLAttributes<HTMLDivElement> {
   options: SelectorOptions;
@@ -58,17 +35,6 @@ export interface SelectorProps extends HTMLAttributes<HTMLDivElement> {
   variant?: 'default' | 'inline';
   renderTriggerLabel?: (option: SelectorOption) => ReactNode;
   renderOptionIndicator?: (option: SelectorOption) => ReactNode;
-}
-
-function focusSibling(current: EventTarget, direction: 'next' | 'prev') {
-  if (!(current instanceof HTMLElement)) return;
-  const sibling =
-    direction === 'next'
-      ? current.nextElementSibling
-      : current.previousElementSibling;
-  if (sibling instanceof HTMLElement) {
-    sibling.focus();
-  }
 }
 
 export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
@@ -127,32 +93,6 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
       }
     };
 
-    const handleOptionKeyDown =
-      (optionValue: string) => (e: KeyboardEvent<HTMLDivElement>) => {
-        switch (e.key) {
-          case 'Enter':
-          case ' ':
-            e.preventDefault();
-            onValueChange?.(optionValue);
-            onOpenChange?.(false);
-            triggerRef.current?.focus();
-            break;
-          case 'ArrowDown':
-            e.preventDefault();
-            focusSibling(e.target, 'next');
-            break;
-          case 'ArrowUp':
-            e.preventDefault();
-            focusSibling(e.target, 'prev');
-            break;
-          case 'Escape':
-            e.preventDefault();
-            onOpenChange?.(false);
-            triggerRef.current?.focus();
-            break;
-        }
-      };
-
     function renderTriggerLabel() {
       if (!selected) return placeholder;
       if (renderTriggerLabelProp) return renderTriggerLabelProp(selected);
@@ -161,40 +101,6 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
       }
       return selected.label;
     }
-
-    function defaultRenderOptionIndicator(option: SelectorOption) {
-      if (option.icon) {
-        return (
-          <Icon
-            name={option.icon}
-            size="sm"
-            className={styles.optionIcon}
-            style={
-              option.iconColor
-                ? ({
-                    '--selector-icon-color': option.iconColor,
-                  } as React.CSSProperties)
-                : undefined
-            }
-          />
-        );
-      }
-      if (option.prefix) {
-        return <span className={styles.optionPrefix}>{option.prefix}</span>;
-      }
-      const isSelected = option.value === value;
-      return (
-        <span
-          className={cn(
-            styles.dot,
-            isSelected ? styles.dotActive : styles.dotInactive,
-          )}
-        />
-      );
-    }
-
-    const renderIndicator =
-      renderOptionIndicatorProp ?? defaultRenderOptionIndicator;
 
     return (
       <div ref={ref} className={cn(styles.selector, className)} {...rest}>
@@ -215,7 +121,7 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
             <Icon
               name={selected.icon}
               size="sm"
-              className={styles.optionIcon}
+              className={styles.triggerIcon}
               style={
                 selected.iconColor
                   ? ({
@@ -249,61 +155,30 @@ export const Selector = forwardRef<HTMLDivElement, SelectorProps>(
               }
             }}
           >
-            {header && <div className={styles.header}>{header}</div>}
-            {options.length === 0 && emptyState && (
-              <div className={styles.emptyState}>{emptyState}</div>
-            )}
-            <div
-              role="listbox"
-              className={styles.options}
+            <OptionList
+              options={options}
+              value={value}
               aria-label={ariaLabel ?? 'Options'}
-            >
-              {options.map((option) => {
-                const isSelected = option.value === value;
-                return (
-                  <div
-                    key={option.value}
-                    role="option"
-                    tabIndex={0}
-                    aria-selected={isSelected}
-                    className={cn(
-                      styles.option,
-                      isSelected && styles.optionSelected,
-                    )}
-                    onClick={() => {
-                      onValueChange?.(option.value);
-                      onOpenChange?.(false);
-                    }}
-                    onKeyDown={handleOptionKeyDown(option.value)}
-                  >
-                    {renderIndicator(option)}
-                    <span className={styles.optionLabel}>{option.label}</span>
-                    {isSelected && (
-                      <Icon
-                        name="check_circle"
-                        size={isInline ? 'sm' : 'md'}
-                        className={styles.checkIcon}
-                      />
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-            {action && (
-              <div className={styles.actionWrapper}>
-                <button
-                  type="button"
-                  className={styles.action}
-                  onClick={() => {
-                    action.onClick();
-                    onOpenChange?.(false);
-                  }}
-                >
-                  <Icon name={action.icon} size="sm" />
-                  <span>{action.label}</span>
-                </button>
-              </div>
-            )}
+              header={header}
+              emptyState={emptyState}
+              renderOptionIndicator={renderOptionIndicatorProp}
+              action={
+                action
+                  ? {
+                      ...action,
+                      onClick: () => {
+                        action.onClick();
+                        onOpenChange?.(false);
+                      },
+                    }
+                  : undefined
+              }
+              onSelect={(optionValue) => {
+                onValueChange?.(optionValue);
+                onOpenChange?.(false);
+                triggerRef.current?.focus();
+              }}
+            />
           </div>
         )}
       </div>

--- a/packages/ds/src/components/_internal/OverlayShell/OverlayShell.tsx
+++ b/packages/ds/src/components/_internal/OverlayShell/OverlayShell.tsx
@@ -48,13 +48,23 @@ export function OverlayShell({
   useEffect(() => {
     if (!open) return;
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape' && !e.defaultPrevented) {
-        onClose();
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      // Only the topmost overlay responds, so Escape never closes a lower
+      // overlay through one stacked above it. Every backdrop portals to
+      // <body> at the same z-index, so the last open one in document order
+      // is the one painted on top.
+      const openBackdrops = document.querySelectorAll(
+        '[data-ds-overlay="open"]',
+      );
+      if (backdropRef.current !== openBackdrops[openBackdrops.length - 1]) {
+        return;
       }
+      e.preventDefault();
+      onClose();
     }
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, onClose]);
+  }, [open, onClose, backdropRef]);
 
   if (typeof document === 'undefined') return null;
   if (!shouldRender && !forceMount) return null;
@@ -71,6 +81,7 @@ export function OverlayShell({
   return createPortal(
     <div
       ref={backdropRef}
+      data-ds-overlay={open ? 'open' : undefined}
       className={cn(styles.backdrop, isVisible && styles.open)}
       style={durationStyle}
     >

--- a/packages/ds/src/index.ts
+++ b/packages/ds/src/index.ts
@@ -106,6 +106,12 @@ export {
   type SelectorAction,
 } from './components/Selector';
 export {
+  OptionList,
+  type OptionListProps,
+  type OptionListOption,
+  type OptionListAction,
+} from './components/OptionList';
+export {
   ProjectPicker,
   type ProjectPickerProps,
   type ProjectPickerProject,

--- a/packages/ds/src/stories/pages/tasks/TasksMobile.stories.tsx
+++ b/packages/ds/src/stories/pages/tasks/TasksMobile.stories.tsx
@@ -17,7 +17,7 @@ import { SectionHeader } from '../../../components/SectionHeader';
 import { StatusDot } from '../../../components/StatusDot';
 import { TaskSection } from '../../../components/TaskSection';
 import { TaskRow } from '../../../components/TaskRow';
-import { Selector } from '../../../components/Selector';
+import { OptionList } from '../../../components/OptionList';
 import { Drawer } from '../../../components/Drawer';
 import {
   TaskDrawer,
@@ -62,21 +62,12 @@ function TasksMobileRender({
   initialTasks?: readonly TaskItem[];
 }) {
   const tasks = useTasksState(initialTasks);
-  const {
-    ref: assigneeRef,
-    open: assigneeOpen,
-    onOpenChange: onAssigneeChange,
-  } = tasks.selectors.assignee;
-  const {
-    ref: priorityRef,
-    open: priorityOpen,
-    onOpenChange: onPriorityChange,
-  } = tasks.selectors.priority;
-  const {
-    ref: ticketRef,
-    open: ticketOpen,
-    onOpenChange: onTicketChange,
-  } = tasks.selectors.ticket;
+  const { open: assigneeOpen, onOpenChange: onAssigneeChange } =
+    tasks.selectors.assignee;
+  const { open: priorityOpen, onOpenChange: onPriorityChange } =
+    tasks.selectors.priority;
+  const { open: ticketOpen, onOpenChange: onTicketChange } =
+    tasks.selectors.ticket;
 
   const [project, setProject] = useState('eng-core');
   const [searchOpen, setSearchOpen] = useState(false);
@@ -99,6 +90,15 @@ function TasksMobileRender({
   }
 
   const activeProject = getProject(project);
+  const selectedAssignee = assigneeOptions.find(
+    (m) => m.value === tasks.form.assignee,
+  );
+  const selectedPriority = priorityOptions.find(
+    (p) => p.value === tasks.form.priority,
+  );
+  const selectedTicket = ticketOptions.find(
+    (t) => t.value === tasks.form.linkedTicket,
+  );
 
   return (
     <div className={styles.shell} style={fabOffsetOverride}>
@@ -147,7 +147,6 @@ function TasksMobileRender({
               onClear={searchQuery ? () => setSearchQuery('') : undefined}
               borderless
               className={searchPillStyles.searchPill}
-              style={{ fontSize: 16 }}
             />
             <button
               type="button"
@@ -469,132 +468,179 @@ function TasksMobileRender({
           </TaskDrawerField>
 
           <TaskDrawerSection label="Properties">
-            <PropertyRow icon="person" label="Assignee">
-              <Selector
-                ref={assigneeRef}
-                options={
-                  tasks.assigneeQuery
-                    ? assigneeOptions.filter((m) =>
-                        m.label
-                          .toLowerCase()
-                          .includes(tasks.assigneeQuery.toLowerCase()),
-                      )
-                    : assigneeOptions
+            <PropertyRow
+              icon="person"
+              label="Assignee"
+              onClick={() => onAssigneeChange(true)}
+              valueLabel={`Assignee: ${selectedAssignee?.label ?? 'Unassigned'}`}
+            >
+              <Avatar
+                variant="profile"
+                size="sm"
+                initial={selectedAssignee?.initial ?? '?'}
+                aria-label={selectedAssignee?.label ?? 'No assignee'}
+                style={
+                  selectedAssignee?.color
+                    ? { backgroundColor: selectedAssignee.color }
+                    : undefined
                 }
-                value={tasks.form.assignee}
-                onValueChange={(v) => {
-                  tasks.setForm((f) => ({ ...f, assignee: v }));
-                  tasks.setAssigneeQuery('');
-                }}
-                open={assigneeOpen}
-                onOpenChange={onAssigneeChange}
-                dropdownAlign="end"
-                variant="inline"
-                aria-label="Select assignee"
-                header={
-                  <SearchInput
-                    value={tasks.assigneeQuery}
-                    onChange={(e) => tasks.setAssigneeQuery(e.target.value)}
-                    placeholder="Search members..."
-                    size="sm"
-                  />
-                }
-                emptyState="No members found"
-                triggerPrefix={(() => {
-                  const selected = assigneeOptions.find(
-                    (m) => m.value === tasks.form.assignee,
-                  );
-                  return (
-                    <Avatar
-                      variant="profile"
-                      initial={selected?.initial ?? '?'}
-                      aria-label={selected?.label ?? 'No assignee'}
-                      style={
-                        selected?.color
-                          ? { backgroundColor: selected.color }
-                          : undefined
-                      }
-                    />
-                  );
-                })()}
-                renderTriggerLabel={(opt) => opt.label}
-                renderOptionIndicator={(opt) => {
-                  const member = assigneeOptions.find(
-                    (m) => m.value === opt.value,
-                  );
-                  return member ? (
-                    <Avatar
-                      variant="profile"
-                      size="sm"
-                      initial={member.initial}
-                      aria-label={member.label}
-                      style={{ backgroundColor: member.color }}
-                    />
-                  ) : null;
-                }}
               />
+              <span>{selectedAssignee?.label ?? 'Unassigned'}</span>
+              <Icon name="expand_more" size="sm" />
             </PropertyRow>
 
-            <PropertyRow icon="signal_cellular_alt" label="Priority">
-              <Selector
-                ref={priorityRef}
-                options={priorityOptions}
-                value={tasks.form.priority}
-                onValueChange={(v) =>
-                  tasks.setForm((f) => ({ ...f, priority: v }))
-                }
-                open={priorityOpen}
-                onOpenChange={onPriorityChange}
-                dropdownAlign="end"
-                variant="inline"
-                aria-label="Select priority"
-              />
+            <PropertyRow
+              icon="signal_cellular_alt"
+              label="Priority"
+              onClick={() => onPriorityChange(true)}
+              valueLabel={`Priority: ${selectedPriority?.label ?? 'None'}`}
+            >
+              {selectedPriority && (
+                <Icon
+                  name={selectedPriority.icon}
+                  size="sm"
+                  style={{ color: selectedPriority.iconColor }}
+                />
+              )}
+              <span>{selectedPriority?.label ?? 'None'}</span>
+              <Icon name="expand_more" size="sm" />
             </PropertyRow>
 
-            <PropertyRow icon="confirmation_number" label="Linked Ticket">
-              <Selector
-                ref={ticketRef}
-                options={
-                  tasks.ticketQuery
-                    ? ticketOptions.filter(
-                        (t) =>
-                          t.label
-                            .toLowerCase()
-                            .includes(tasks.ticketQuery.toLowerCase()) ||
-                          (t.prefix ?? '')
-                            .toLowerCase()
-                            .includes(tasks.ticketQuery.toLowerCase()),
-                      )
-                    : ticketOptions
-                }
-                value={tasks.form.linkedTicket}
-                onValueChange={(v) => {
-                  tasks.setForm((f) => ({ ...f, linkedTicket: v }));
-                  tasks.setTicketQuery('');
-                }}
-                open={ticketOpen}
-                onOpenChange={onTicketChange}
-                placeholder="Search ticket..."
-                header={
-                  <SearchInput
-                    value={tasks.ticketQuery}
-                    onChange={(e) => tasks.setTicketQuery(e.target.value)}
-                    placeholder="Search tickets..."
-                    size="sm"
-                  />
-                }
-                variant="inline"
-                dropdownAlign="end"
-                action={{
-                  label: 'Create new ticket',
-                  icon: 'add',
-                  onClick: () => {},
-                }}
-                emptyState="No results found"
-                aria-label="Linked ticket"
-              />
+            <PropertyRow
+              icon="confirmation_number"
+              label="Linked Ticket"
+              onClick={() => onTicketChange(true)}
+              valueLabel={`Linked ticket: ${
+                selectedTicket
+                  ? `${selectedTicket.prefix}, ${selectedTicket.label}`
+                  : 'None'
+              }`}
+            >
+              <span>{selectedTicket ? selectedTicket.prefix : 'None'}</span>
+              <Icon name="expand_more" size="sm" />
             </PropertyRow>
           </TaskDrawerSection>
+
+          <BottomSheet
+            open={assigneeOpen}
+            onClose={() => {
+              onAssigneeChange(false);
+              tasks.setAssigneeQuery('');
+            }}
+            aria-label="Select assignee"
+          >
+            <SectionHeader headingLevel={3}>Assignee</SectionHeader>
+            <OptionList
+              options={
+                tasks.assigneeQuery
+                  ? assigneeOptions.filter((m) =>
+                      m.label
+                        .toLowerCase()
+                        .includes(tasks.assigneeQuery.toLowerCase()),
+                    )
+                  : assigneeOptions
+              }
+              value={tasks.form.assignee}
+              onSelect={(v) => {
+                tasks.setForm((f) => ({ ...f, assignee: v }));
+                tasks.setAssigneeQuery('');
+                onAssigneeChange(false);
+              }}
+              header={
+                <SearchInput
+                  value={tasks.assigneeQuery}
+                  onChange={(e) => tasks.setAssigneeQuery(e.target.value)}
+                  placeholder="Search members..."
+                  aria-label="Search members"
+                  size="sm"
+                />
+              }
+              emptyState="No members found"
+              renderOptionIndicator={(opt) => {
+                const member = assigneeOptions.find(
+                  (m) => m.value === opt.value,
+                );
+                return member ? (
+                  <Avatar
+                    variant="profile"
+                    size="sm"
+                    initial={member.initial}
+                    aria-label={member.label}
+                    style={{ backgroundColor: member.color }}
+                  />
+                ) : null;
+              }}
+              aria-label="Members"
+            />
+          </BottomSheet>
+
+          <BottomSheet
+            open={priorityOpen}
+            onClose={() => onPriorityChange(false)}
+            aria-label="Select priority"
+          >
+            <SectionHeader headingLevel={3}>Priority</SectionHeader>
+            <OptionList
+              options={priorityOptions}
+              value={tasks.form.priority}
+              onSelect={(v) => {
+                tasks.setForm((f) => ({ ...f, priority: v }));
+                onPriorityChange(false);
+              }}
+              aria-label="Priority"
+            />
+          </BottomSheet>
+
+          <BottomSheet
+            open={ticketOpen}
+            onClose={() => {
+              onTicketChange(false);
+              tasks.setTicketQuery('');
+            }}
+            aria-label="Select linked ticket"
+          >
+            <SectionHeader headingLevel={3}>Linked Ticket</SectionHeader>
+            <OptionList
+              options={
+                tasks.ticketQuery
+                  ? ticketOptions.filter(
+                      (t) =>
+                        t.label
+                          .toLowerCase()
+                          .includes(tasks.ticketQuery.toLowerCase()) ||
+                        t.prefix
+                          .toLowerCase()
+                          .includes(tasks.ticketQuery.toLowerCase()),
+                    )
+                  : ticketOptions
+              }
+              value={tasks.form.linkedTicket}
+              onSelect={(v) => {
+                tasks.setForm((f) => ({ ...f, linkedTicket: v }));
+                tasks.setTicketQuery('');
+                onTicketChange(false);
+              }}
+              header={
+                <SearchInput
+                  value={tasks.ticketQuery}
+                  onChange={(e) => tasks.setTicketQuery(e.target.value)}
+                  placeholder="Search tickets..."
+                  aria-label="Search tickets"
+                  size="sm"
+                />
+              }
+              action={{
+                label: 'Create new ticket',
+                icon: 'add',
+                onClick: () => {
+                  onTicketChange(false);
+                  tasks.setTicketQuery('');
+                },
+              }}
+              emptyState="No results found"
+              aria-label="Tickets"
+            />
+          </BottomSheet>
 
           <TaskDrawerSection label="Recent Tasks">
             <RecentTaskList items={recentTasks} />


### PR DESCRIPTION

https://github.com/user-attachments/assets/d9dd14b0-cbc4-4460-a13b-1e3d26309162


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches overlay stacking/Escape behavior and refactors Selector list UI—regressions could affect desktop dropdowns and nested drawer/sheet flows, though coverage is added.
> 
> **Overview**
> Mobile task creation/editing now picks **assignee**, **priority**, and **linked ticket** via **bottom sheets** with a shared **`OptionList`** instead of inline **`Selector`** dropdowns on property rows. **`PropertyRow`** gains **`valueLabel`** so triggers expose names like `Assignee: Alex H.` for tests and screen readers.
> 
> A new **`OptionList`** component (listbox, search header, empty state, footer action) is extracted from **`Selector`**, which now composes it for desktop dropdowns. **`OverlayShell`** only handles **Escape** on the topmost open overlay (`data-ds-overlay`), so a picker sheet can dismiss without closing the task drawer. **`SearchInput`** uses a coarse-pointer **16px** rule to avoid iOS focus zoom, replacing one-off inline font sizes.
> 
> Playwright adds **metadata picker** coverage and optional **`E2E_BASE_URL`** (skips local Storybook server when set).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96ba27769a074429f70d2d4e653ab950deb4001a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->